### PR TITLE
PRESS7-21: Optimize Composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     }
   ],
   "config": {
+    "apcu-autoloader": true,
     "optimize-autoloader": true,
     "sort-packages": true,
     "platform": {


### PR DESCRIPTION
## Proposed changes

Configures Composer to use APCu cache optimization for the autoloader. 

On my local install the improvements were _good_ but not amazing.

**Before** the change:
![Screenshot 2025-02-26 at 8 57 48 AM](https://github.com/user-attachments/assets/990ec10e-efea-4950-90bd-c850ccacadcd)

**After** the change:
![image](https://github.com/user-attachments/assets/d4e63d7a-1a88-4d3e-8028-f792d18b8091)

For reference, using Authoritative class maps showed a small improvement, but not as much as APCu cache
![Screenshot 2025-02-26 at 9 00 06 AM](https://github.com/user-attachments/assets/188badf2-ee1c-4a97-bd1c-950883271535)

**However**, on a Bluehost site the improvements are quite striking. The autolo

**Before** the change:
![Screenshot 2025-02-26 at 9 15 04 AM](https://github.com/user-attachments/assets/4b127574-f118-4ed7-af9a-7ce7ff0c8cb0)

**After** the change:
![Screenshot 2025-02-26 at 9 15 25 AM](https://github.com/user-attachments/assets/54b1bcf0-357d-4fd2-b7b4-ead0f45df271)
