### PR TITLE
Remove translation-action-scripts from gitignore

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: newfold-labs/workflows/.github/workflows/reusable-auto-translate.yml@main
+    uses: newfold-labs/workflows/.github/workflows/reusable-azure-ai-translate.yml@main
     with:
       text_domain: 'wp-plugin-bluehost'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -1,4 +1,4 @@
-name: Auto Translate
+name: Check for Updates to Translations
 
 on:
   push:
@@ -16,11 +16,11 @@ permissions: {}
 
 jobs:
   translate:
-    name: 'Trigger Auto-Translate Workflow'
+    name: 'Check and upddate translations'
     permissions:
       contents: write
       pull-requests: write
-    uses: newfold-labs/workflows/.github/workflows/auto-translate.yml@main
+    uses: newfold-labs/workflows/.github/workflows/reusable-auto-translate.yml@main
     with:
       text_domain: 'wp-plugin-bluehost'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -16,7 +16,7 @@ permissions: {}
 
 jobs:
   translate:
-    name: 'Check and upddate translations'
+    name: 'Check and update translations'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -1,0 +1,28 @@
+name: Auto Translate
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the branch that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  translate:
+    name: 'Trigger Auto-Translate Workflow'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: newfold-labs/workflows/.github/workflows/auto-translate.yml@main
+    with:
+      text_domain: 'wp-plugin-bluehost'
+    secrets:
+      TRANSLATOR_API_KEY: ${{ secrets.TRANSLATOR_API_KEY }}
+      NEWFOLD_ACCESS_TOKEN: ${{ secrets.NEWFOLD_ACCESS_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ cypress.env.json
 *.log
 *.sql
 *.zip
-
-# GitHub Action related files and directories
-/translation-action-scripts

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ cypress.env.json
 *.log
 *.sql
 *.zip
+
+# GitHub Action related files and directories
+/translation-action-scripts


### PR DESCRIPTION
## Proposed changes

As we are using GitHub actions runner temp directory to store the script, removing the `translation-action-scripts` from the .gitignore.