### PR TITLE
add redirect for specific route

### DIFF
--- a/src/app/data/routes.js
+++ b/src/app/data/routes.js
@@ -71,10 +71,7 @@ export const AppRoutes = () => {
 				element={ <MyPluginsAndToolsRedirect /> }
 			/>
 			{ /* Add specific route for staging redirect. */ }
-			<Route
-				path="/staging"
-				element={ <StagingRedirect /> }
-			/>
+			<Route path="/staging" element={ <StagingRedirect /> } />
 			<Route
 				path="*"
 				element={

--- a/src/app/pages/home/QuickLinksCard.js
+++ b/src/app/pages/home/QuickLinksCard.js
@@ -10,7 +10,7 @@ const QuickLinksCard = ( {} ) => {
 			<div className="nfd-grid nfd-gap-4 nfd-grid-cols-1">
 				<a
 					className="nfd-no-underline nfd-card-link nfd-card-link-mini"
-					href="#/hosting"
+					href="admin.php?page=nfd-hosting"
 					data-cy="hosting-card"
 				>
 					<Card className="wppbh-hosting-card nfd-card-mini nfd-py-4">


### PR DESCRIPTION
## Proposed changes

This PR adds a redirect route for the `/my_plugins_and_tools` path to resolve the issue where users clicking "View All your Plugin" were seeing a "nothing here" message instead of being taken to the solutions page. The redirect now properly takes users to `/wp-admin/admin.php?page=solutions&category=all` as specified in the JIRA issue.

**Fixes:** [JIRA Issue - "View All your Plugin" redirects to blank page](https://jira.newfold.com/browse/SOFT-167625)

## Type of Change

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

**Bug Reproduction Steps:**
1. Login to Account
2. Purchase WP solution for any site
3. Go to site
4. Click on "View All your Plugin"
5. Redirects to plugin page but shows "nothing here" message

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

https://github.com/user-attachments/assets/75758a81-1653-4bf1-aee5-5ecf1d2f5fc5


<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

**Note:** No tests were added as this is a temporary fix and not a permanent solution.

## Pre-deployment Checklist

- [ ] No environmental variables or dependencies required for this change

## Post-deployment Checklist

How can the change be verified?

- [x] Navigate to `wp-admin/admin.php?page=bluehost#/my_plugins_and_tools` and verify it redirects to `/wp-admin/admin.php?page=solutions&category=all`
- [x] Verify that other routes continue to work as expected
- [x] Test that the "nothing here" message no longer appears for the my_plugins_and_tools route

## Further comments

This solution implements the redirect at the React Router level by adding a specific route for `/my_plugins_and_tools` that renders a redirect component. This approach is cleaner than checking URLs in the component lifecycle and follows React Router best practices.

**Important:** This is a temporary fix to resolve the immediate user experience issue. The proper long-term solution would involve fixing the underlying marketplace module that generates the "View All your Plugin" link to point to the correct URL from the start.

**Alternatives considered:**
1. **Component-level URL checking**: Initially implemented URL pattern checking in the AppBody component, but this was less clean and harder to maintain.
2. **Catch-all route modification**: Considered modifying the existing catch-all route, but this would affect other unknown routes.
3. **Router-level redirect**: Chosen as the best approach because it's explicit, maintainable, and follows React Router conventions.

The redirect component (`MyPluginsAndToolsRedirect`) is simple and focused, using `window.location.href` to perform the redirect and returning `null` to prevent any rendering. The code follows WordPress coding standards with proper JSDoc documentation and formatting.


edit: add jira link