### PR TITLE
Update upload-asset-on-release workflow by adding step to upload plugin release zip to Cloudflare R2

### DIFF
--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -135,6 +135,25 @@ jobs:
         run: |
           gh release upload "$TAG_NAME" "$DIST/$PACKAGE.zip"
 
+      - name: Upload Zip to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          DIST: ${{ steps.workflow.outputs.DIST }}
+          PACKAGE: ${{ steps.workflow.outputs.PACKAGE }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y awscli
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          echo "Uploading $PACKAGE.zip to R2 bucket: $R2_BUCKET_NAME"
+          aws s3 cp "$DIST/$PACKAGE.zip" \
+            "s3://${R2_BUCKET_NAME}/uploads/free/$PACKAGE.zip" \
+            --endpoint-url "$ENDPOINT"
+
       - name: Clear cache for release API
         if: ${{ github.repository == 'newfold-labs/wp-plugin-bluehost' }}
         run: |


### PR DESCRIPTION
## Proposed changes

Add a step to the existing `upload-asset-on-release` workflow that uploads the generated plugin ZIP to **Cloudflare R2** after the release asset is created. The workflow continues to attach the zip to the GitHub Release (unchanged) and also mirrors the artifact into an R2 bucket so release artifacts can be served/stored via Cloudflare new [wp-release-api](https://github.com/newfold-labs/wp-release-api). The upload uses the S3-compatible API (AWS CLI against the R2 endpoint) and stores objects under a repository/tag-based path for easy lookup.

**Files changed**

* `.github/workflows/package-plugin.yml` — adds the `Upload Zip to R2` step (runs after `Upload Release Asset`).

**Why**

* We are working on a new wp-release service on Cloudflare infrastructure. Please see [wp-release-api](https://github.com/newfold-labs/wp-release-api) for more details.

## Type of Change


#### Production

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Dependency update
* [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

* [ ] Tests
* [ ] Dependency update
* [x] Environment update / refactoring
* [ ] Documentation Update

## Repository setup

Please add the following **Actions secrets** to the repository prior to merging:

* `R2_ACCESS_KEY_ID`
* `R2_SECRET_ACCESS_KEY`
* `R2_BUCKET_NAME`
* `R2_ACCOUNT_ID`

