### PR TITLE
Fix 3.3.3 upgrade routine to not flush Redis object cache

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -200,17 +200,44 @@ $pluginUpdater->setDataOverrides(
 // Handle any upgrade routines (only in the admin)
 if ( is_admin() ) {
 
+	$bluehost_stored_version = get_option( 'bluehost_plugin_version', '0.1.0' );
+
 	// Handle plugin upgrades
 	$upgrade_handler = new UpgradeHandler(
-		BLUEHOST_PLUGIN_DIR . '/inc/upgrades',                    // Directory where upgrade routines live
-		get_option( 'bluehost_plugin_version', '0.1.0' ), // Old plugin version (from database)
-		BLUEHOST_PLUGIN_VERSION                                  // New plugin version (from code)
+		BLUEHOST_PLUGIN_DIR . '/inc/upgrades', // Directory where upgrade routines live
+		$bluehost_stored_version, // Old plugin version (from database)
+		BLUEHOST_PLUGIN_VERSION // New plugin version (from code)
 	);
+
+	if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+		$upgrade_debug = array(
+			'stored_version' => $bluehost_stored_version,
+			'code_version'   => BLUEHOST_PLUGIN_VERSION,
+			'will_run'       => $upgrade_handler->should_upgrade(),
+		);
+		if ( $upgrade_handler->should_upgrade() ) {
+			$available = $upgrade_handler->get_available_upgrade_routines();
+			$required  = $upgrade_handler->get_required_upgrade_routines( $available );
+			$upgrade_debug['routines_scheduled'] = array_map(
+				'basename',
+				$required
+			);
+			$upgrade_debug['routine_count'] = count( $required );
+		}
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- gated by WP_DEBUG_LOG
+		error_log( '[Bluehost Plugin] upgrade: ' . wp_json_encode( $upgrade_debug ) );
+	}
 
 	// Returns true if the old version doesn't match the new version
 	$did_upgrade = $upgrade_handler->maybe_upgrade();
 
 	if ( $did_upgrade ) {
+		if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- gated by WP_DEBUG_LOG
+			error_log(
+				'[Bluehost Plugin] upgrade: completed, updating option bluehost_plugin_version to ' . BLUEHOST_PLUGIN_VERSION
+			);
+		}
 		// If an upgrade occurred, update the new version in the database to prevent running the routine(s) again.
 		update_option( 'bluehost_plugin_version', BLUEHOST_PLUGIN_VERSION, true );
 	}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -200,44 +200,17 @@ $pluginUpdater->setDataOverrides(
 // Handle any upgrade routines (only in the admin)
 if ( is_admin() ) {
 
-	$bluehost_stored_version = get_option( 'bluehost_plugin_version', '0.1.0' );
-
 	// Handle plugin upgrades
 	$upgrade_handler = new UpgradeHandler(
-		BLUEHOST_PLUGIN_DIR . '/inc/upgrades', // Directory where upgrade routines live
-		$bluehost_stored_version, // Old plugin version (from database)
-		BLUEHOST_PLUGIN_VERSION // New plugin version (from code)
+		BLUEHOST_PLUGIN_DIR . '/inc/upgrades',                    // Directory where upgrade routines live
+		get_option( 'bluehost_plugin_version', '0.1.0' ), // Old plugin version (from database)
+		BLUEHOST_PLUGIN_VERSION                                  // New plugin version (from code)
 	);
-
-	if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
-		$upgrade_debug = array(
-			'stored_version' => $bluehost_stored_version,
-			'code_version'   => BLUEHOST_PLUGIN_VERSION,
-			'will_run'       => $upgrade_handler->should_upgrade(),
-		);
-		if ( $upgrade_handler->should_upgrade() ) {
-			$available = $upgrade_handler->get_available_upgrade_routines();
-			$required  = $upgrade_handler->get_required_upgrade_routines( $available );
-			$upgrade_debug['routines_scheduled'] = array_map(
-				'basename',
-				$required
-			);
-			$upgrade_debug['routine_count'] = count( $required );
-		}
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- gated by WP_DEBUG_LOG
-		error_log( '[Bluehost Plugin] upgrade: ' . wp_json_encode( $upgrade_debug ) );
-	}
 
 	// Returns true if the old version doesn't match the new version
 	$did_upgrade = $upgrade_handler->maybe_upgrade();
 
 	if ( $did_upgrade ) {
-		if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- gated by WP_DEBUG_LOG
-			error_log(
-				'[Bluehost Plugin] upgrade: completed, updating option bluehost_plugin_version to ' . BLUEHOST_PLUGIN_VERSION
-			);
-		}
 		// If an upgrade occurred, update the new version in the database to prevent running the routine(s) again.
 		update_option( 'bluehost_plugin_version', BLUEHOST_PLUGIN_VERSION, true );
 	}

--- a/composer.json
+++ b/composer.json
@@ -176,7 +176,7 @@
     "newfold-labs/wp-module-onboarding": "^3.3.6",
     "newfold-labs/wp-module-onboarding-data": "^1.2.23",
     "newfold-labs/wp-module-patterns": "^2.12.2",
-    "newfold-labs/wp-module-performance": "^3.7.7",
+    "newfold-labs/wp-module-performance": "^3.7.8",
     "newfold-labs/wp-module-pls": "^1.1.3",
     "newfold-labs/wp-module-reset": "^1.0.2",
     "newfold-labs/wp-module-runtime": "^1.2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -11690,5 +11690,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c1081a101710e7c8e797032987cf61f",
+    "content-hash": "9335bc77d8f1760dcce8ae92555aa394",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -3079,16 +3079,16 @@
         },
         {
             "name": "newfold-labs/wp-module-performance",
-            "version": "3.7.7",
+            "version": "3.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-performance.git",
-                "reference": "7faf943174b4ff6359e7060a97991aede67c816b"
+                "reference": "ef590de7cf145cd68d12ca5cc3745bc4a9f9af46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-performance/zipball/7faf943174b4ff6359e7060a97991aede67c816b",
-                "reference": "7faf943174b4ff6359e7060a97991aede67c816b",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-performance/zipball/ef590de7cf145cd68d12ca5cc3745bc4a9f9af46",
+                "reference": "ef590de7cf145cd68d12ca5cc3745bc4a9f9af46",
                 "shasum": ""
             },
             "require": {
@@ -3155,7 +3155,7 @@
                     "vendor/bin/wp i18n update-po ./languages/wp-module-performance.pot ./languages"
                 ],
                 "i18n-pot": [
-                    "vendor/bin/wp i18n make-pot . ./languages/wp-module-performance.pot --domain=wp-module-performance --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-performance/issues\",\"POT-Creation-Date\":null}' --exclude=src,tests,assets,wordpress --include=build/*.min.js"
+                    "vendor/bin/wp i18n make-pot . ./languages/wp-module-performance.pot --domain=wp-module-performance --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-performance/issues\",\"POT-Creation-Date\":null}' --exclude=src,tests,assets,wordpress --include=includes/*,build/*.min.js"
                 ],
                 "test": [
                     "phpunit --bootstrap tests/phpunit/bootstrap.php",
@@ -3178,10 +3178,10 @@
             ],
             "description": "A module for managing caching functionality.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-performance/tree/3.7.7",
+                "source": "https://github.com/newfold-labs/wp-module-performance/tree/3.7.8",
                 "issues": "https://github.com/newfold-labs/wp-module-performance/issues"
             },
-            "time": "2026-04-01T22:27:26+00:00"
+            "time": "2026-04-03T12:32:54+00:00"
         },
         {
             "name": "newfold-labs/wp-module-pls",
@@ -11690,5 +11690,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/inc/upgrades/3.3.3.php
+++ b/inc/upgrades/3.3.3.php
@@ -6,5 +6,5 @@ use NewfoldLabs\WP\Module\Performance\Cache\Types\File;
 // Remove the file-based caching rules from the .htaccess file
 File::removeRules();
 
-// Purge the file-based cache
-( new CachePurgingService( array( new File() ) ) )->purge_all();
+// Purge the file-based cache only (do not flush Redis / object cache).
+( new CachePurgingService( array( new File() ) ) )->purge_page_caches();


### PR DESCRIPTION
The upgrade routine was calling purge_all() which flushes the Redis object cache in addition to the file-based page cache. When this runs during an SSO login request (user SSOs in from hosting panel, WordPress boots, upgrade handler fires in bootstrap.php), the Redis flush can destroy the SSO token before authentication completes, causing SSO failure.

Changed to purge_page_caches() which only clears the file-based cache — the only cache type relevant to this upgrade.

The better solution would be https://newfold.atlassian.net/browse/HOST-7828 but this might take time.

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->