### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -20,8 +20,8 @@ jobs:
   translate:
     name: 'Check and update translations'
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write           # Required for reusable workflow to commit translation updates.
+      pull-requests: write      # Required for reusable workflow to open or update pull requests.
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-plugin-bluehost'

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -19,6 +19,7 @@ permissions: {}
 jobs:
   translate:
     name: 'Check and update translations'
+    timeout-minutes: 60
     permissions:
       contents: write           # Required for reusable workflow to commit translation updates.
       pull-requests: write      # Required for reusable workflow to open or update pull requests.

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -19,7 +19,6 @@ permissions: {}
 jobs:
   translate:
     name: 'Check and update translations'
-    timeout-minutes: 60
     permissions:
       contents: write           # Required for reusable workflow to commit translation updates.
       pull-requests: write      # Required for reusable workflow to open or update pull requests.

--- a/.github/workflows/cloudflare-clear-cache.yml
+++ b/.github/workflows/cloudflare-clear-cache.yml
@@ -15,6 +15,7 @@ jobs:
   clear-cache:
     name: Clear the Cloudflare cache
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Clear cache for release API
         if: ${{ github.repository == 'newfold-labs/wp-plugin-bluehost' }}

--- a/.github/workflows/cloudflare-clear-cache.yml
+++ b/.github/workflows/cloudflare-clear-cache.yml
@@ -15,6 +15,7 @@ jobs:
   clear-cache:
     name: Clear the Cloudflare cache
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {}
     steps:
       - name: Clear cache for release API

--- a/.github/workflows/codecoverage-cleanup.yml
+++ b/.github/workflows/codecoverage-cleanup.yml
@@ -18,14 +18,16 @@ on:
     # Weekly on Sunday at 00:00 UTC
     - cron: '0 0 * * 0'
 
-# Permissions set per-job to avoid overly broad write at workflow level.
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   get-merged-pr-commits:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      pull-requests: read    # Required for gh to list commits on the merged pull request.
     outputs:
       shas: ${{ steps.shas.outputs.list }}
     steps:
@@ -42,7 +44,7 @@ jobs:
     needs: get-merged-pr-commits
     if: always() && needs.get-merged-pr-commits.result == 'success'
     permissions:
-      contents: write
+      contents: write         # Required for reusable workflow to prune coverage output on gh-pages.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
     with:
       shas: ${{ needs.get-merged-pr-commits.outputs.shas }}
@@ -64,7 +66,7 @@ jobs:
   cleanup-scheduled:
     if: github.event_name == 'schedule'
     permissions:
-      contents: write
+      contents: write         # Required for reusable workflow to prune coverage output on gh-pages.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
     with:
       shas: ''

--- a/.github/workflows/codecoverage-cleanup.yml
+++ b/.github/workflows/codecoverage-cleanup.yml
@@ -26,6 +26,7 @@ jobs:
   get-merged-pr-commits:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       pull-requests: read    # Required for gh to list commits on the merged pull request.
     outputs:
@@ -43,6 +44,7 @@ jobs:
   cleanup-on-merge:
     needs: get-merged-pr-commits
     if: always() && needs.get-merged-pr-commits.result == 'success'
+    timeout-minutes: 30
     permissions:
       contents: write         # Required for reusable workflow to prune coverage output on gh-pages.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
@@ -54,8 +56,9 @@ jobs:
 
   cleanup-on-branch-delete:
     if: github.event_name == 'delete' && github.event.ref_type == 'branch'
+    timeout-minutes: 30
     permissions:
-      contents: write
+      contents: write         # Required for reusable workflow to prune coverage output on gh-pages.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
     with:
       shas: ''
@@ -65,6 +68,7 @@ jobs:
 
   cleanup-scheduled:
     if: github.event_name == 'schedule'
+    timeout-minutes: 30
     permissions:
       contents: write         # Required for reusable workflow to prune coverage output on gh-pages.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -15,12 +15,15 @@ on:
       - release/*
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    # No repository clone or token use; only parses github.repository for reusable workflow inputs.
+    permissions: {}
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -31,8 +34,8 @@ jobs:
   codecoverage:
     needs: get-repo-name
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write           # Required for reusable workflow to push coverage to GitHub Pages.
+      pull-requests: write      # Required for reusable workflow to post or update PR comments.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -22,6 +22,7 @@ permissions: {}
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # No repository clone or token use; only parses github.repository for reusable workflow inputs.
     permissions: {}
     outputs:
@@ -33,6 +34,7 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
+    timeout-minutes: 120
     permissions:
       contents: write           # Required for reusable workflow to push coverage to GitHub Pages.
       pull-requests: write      # Required for reusable workflow to post or update PR comments.

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -34,7 +34,6 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    timeout-minutes: 120
     permissions:
       contents: write           # Required for reusable workflow to push coverage to GitHub Pages.
       pull-requests: write      # Required for reusable workflow to post or update PR comments.

--- a/.github/workflows/create-milestones.yml
+++ b/.github/workflows/create-milestones.yml
@@ -18,8 +18,7 @@ jobs:
   create-milestone:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      contents: read
+      issues: write             # Required to create milestones via the GitHub REST API.
 
     steps:
       - name: Create Milestone

--- a/.github/workflows/create-milestones.yml
+++ b/.github/workflows/create-milestones.yml
@@ -17,6 +17,7 @@ permissions: {}
 jobs:
   create-milestone:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write             # Required to create milestones via the GitHub REST API.
 

--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -13,6 +13,7 @@ jobs:
   delete:
     name: On Delete Release
     runs-on: ubuntu-latest
+    permissions: {}
     if: ${{ github.repository == 'newfold-labs/wp-plugin-bluehost' }}
     steps:
 

--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -13,6 +13,7 @@ jobs:
   delete:
     name: On Delete Release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {}
     if: ${{ github.repository == 'newfold-labs/wp-plugin-bluehost' }}
     steps:

--- a/.github/workflows/deploy-and-test.yml
+++ b/.github/workflows/deploy-and-test.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read           # Required to clone the repo.
       actions: write          # Required to upload the plugin zip artifact.

--- a/.github/workflows/deploy-and-test.yml
+++ b/.github/workflows/deploy-and-test.yml
@@ -17,7 +17,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read           # Required to clone the repo.
+      actions: write          # Required to upload the plugin zip artifact.
     strategy:
       matrix:
         environment: [ bluehost-shared ]

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -24,6 +24,7 @@ permissions: {}
 jobs:
   ESLint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read           # Required to clone the repo.
     steps:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -25,7 +25,7 @@ jobs:
   ESLint:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read           # Required to clone the repo.
     steps:
 
       - name: Checkout

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -15,6 +15,7 @@ permissions: {}
 jobs:
   call-crowdin-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
+    timeout-minutes: 60
     permissions:
       contents: write           # Required for reusable workflow to commit downloaded translations.
       pull-requests: write      # Required for reusable workflow to open or update pull requests.

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -16,8 +16,8 @@ jobs:
   call-crowdin-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write           # Required for reusable workflow to commit downloaded translations.
+      pull-requests: write      # Required for reusable workflow to open or update pull requests.
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -15,7 +15,6 @@ permissions: {}
 jobs:
   call-crowdin-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
-    timeout-minutes: 60
     permissions:
       contents: write           # Required for reusable workflow to commit downloaded translations.
       pull-requests: write      # Required for reusable workflow to open or update pull requests.

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -10,6 +10,7 @@ permissions: {}
 jobs:
   call-crowdin-upload-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
+    timeout-minutes: 60
     permissions:
       contents: write           # Required for reusable workflow to commit updated source strings.
       pull-requests: write      # Required for reusable workflow to open or update pull requests.

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -11,8 +11,8 @@ jobs:
   call-crowdin-upload-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write           # Required for reusable workflow to commit updated source strings.
+      pull-requests: write      # Required for reusable workflow to open or update pull requests.
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -10,7 +10,6 @@ permissions: {}
 jobs:
   call-crowdin-upload-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
-    timeout-minutes: 60
     permissions:
       contents: write           # Required for reusable workflow to commit updated source strings.
       pull-requests: write      # Required for reusable workflow to open or update pull requests.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,7 @@ jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read           # Required to clone the repo.
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,8 +38,7 @@ jobs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-
+      contents: read           # Required to clone the repo.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/newfold-prepare-release.yml
+++ b/.github/workflows/newfold-prepare-release.yml
@@ -32,6 +32,7 @@ jobs:
   # This runs the newfold reusable-plugin-prep-release workflow for this plugin to prepare a release.
   prep-release:
     name: Prepare Release
+    timeout-minutes: 60
     permissions:
       contents: write           # Required for reusable workflow to push release preparation commits.
       pull-requests: write      # Required for reusable workflow to open or update the release pull request.

--- a/.github/workflows/newfold-prepare-release.yml
+++ b/.github/workflows/newfold-prepare-release.yml
@@ -33,8 +33,8 @@ jobs:
   prep-release:
     name: Prepare Release
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write           # Required for reusable workflow to push release preparation commits.
+      pull-requests: write      # Required for reusable workflow to open or update the release pull request.
     uses: newfold-labs/workflows/.github/workflows/reusable-plugin-prep-release.yml@main
     with:
       plugin-repo: ${{ github.repository }}

--- a/.github/workflows/newfold-prepare-release.yml
+++ b/.github/workflows/newfold-prepare-release.yml
@@ -32,7 +32,6 @@ jobs:
   # This runs the newfold reusable-plugin-prep-release workflow for this plugin to prepare a release.
   prep-release:
     name: Prepare Release
-    timeout-minutes: 60
     permissions:
       contents: write           # Required for reusable workflow to push release preparation commits.
       pull-requests: write      # Required for reusable workflow to open or update the release pull request.

--- a/.github/workflows/performance-cron.yml
+++ b/.github/workflows/performance-cron.yml
@@ -14,6 +14,7 @@ jobs:
   visit-site:
     name: Visit the performance test site
     runs-on: ubuntu-latest
+    permissions: {}
     environment: Performance Test Site
     env:
       BASE_URL: ${{ vars.BASE_URL }}

--- a/.github/workflows/performance-cron.yml
+++ b/.github/workflows/performance-cron.yml
@@ -14,6 +14,7 @@ jobs:
   visit-site:
     name: Visit the performance test site
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions: {}
     environment: Performance Test Site
     env:

--- a/.github/workflows/playground-cleanup.yml
+++ b/.github/workflows/playground-cleanup.yml
@@ -12,11 +12,11 @@ jobs:
     name: Remove Preview from GitHub Pages
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pages: write
-      id-token: write
-      deployments: read
-
+      contents: read           # Required to clone the repo.
+      pages: write           # Required to publish the updated GitHub Pages site.
+      id-token: write        # Required for OIDC authentication to GitHub Pages.
+      deployments: read      # Required for actions/deploy-pages to read deployment metadata.
+      actions: read           # Required for actions/download-artifact to fetch Pages artifacts with GITHUB_TOKEN.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/playground-cleanup.yml
+++ b/.github/workflows/playground-cleanup.yml
@@ -11,6 +11,7 @@ jobs:
   cleanup-preview:
     name: Remove Preview from GitHub Pages
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read           # Required to clone the repo.
       pages: write           # Required to publish the updated GitHub Pages site.

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -11,6 +11,7 @@ permissions: {}
 jobs:
   playground-preview:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read          # Required to clone the repo.
       pull-requests: write    # Required for github-script to upsert PR comments.

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -4,16 +4,21 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   playground-preview:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.fork == false
-
     permissions:
-      contents: read
-      pull-requests: write
-      pages: write
-      id-token: write
+      contents: read          # Required to clone the repo.
+      pull-requests: write    # Required for github-script to upsert PR comments.
+      pages: write            # Required to publish and update GitHub Pages.
+      id-token: write         # Required for OIDC authentication to GitHub Pages.
+      actions: read           # Required to list workflow run artifacts.
+      actions: write          # Required to delete stale github-pages artifacts before upload.
+    if: github.event.pull_request.head.repo.fork == false
 
     concurrency:
       group: pages-${{ github.event.pull_request.number }}

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -17,8 +17,7 @@ jobs:
       pull-requests: write    # Required for github-script to upsert PR comments.
       pages: write            # Required to publish and update GitHub Pages.
       id-token: write         # Required for OIDC authentication to GitHub Pages.
-      actions: read           # Required to list workflow run artifacts.
-      actions: write          # Required to delete stale github-pages artifacts before upload.
+      actions: write          # Required to list and delete stale github-pages workflow artifacts before upload.
     if: github.event.pull_request.head.repo.fork == false
 
     concurrency:

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -23,8 +23,8 @@ jobs:
     timeout-minutes: 1
     outputs:
       run_matrix: ${{ steps.check.outputs.run_matrix }}
-    permissions:
-      contents: read
+    # Job reads only the workflow event payload; no repository clone or GitHub API calls.
+    permissions: {}
 
     steps:
       - name: Decide whether to run matrix
@@ -63,7 +63,8 @@ jobs:
     needs: should-run-matrix
     if: needs.should-run-matrix.outputs.run_matrix == 'true'
     permissions:
-      contents: read
+      contents: read            # Required to clone the repo.
+      actions: write           # Required to upload per-matrix Playwright report artifacts.
     strategy:
       fail-fast: false
       matrix:
@@ -217,15 +218,10 @@ jobs:
       - test
     if: ${{ always() && needs.test.result != 'skipped' }}
     permissions:
-      contents: read
+      contents: read            # Required to clone the repo for the summary script.
+      actions: read            # Required to download matrix Playwright artifacts from this workflow run.
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Download all Playwright matrix artifacts
         if: always()
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:

--- a/.github/workflows/playwright-tests-beta.yml
+++ b/.github/workflows/playwright-tests-beta.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
-      contents: read
+      contents: read            # Required to clone the repo.
+      actions: write           # Required to upload Playwright test result artifacts.
 
     steps:
       - name: Checkout

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -26,7 +26,8 @@ jobs:
       dist: ${{ steps.workflow.outputs.DIST }}
       package: ${{ steps.workflow.outputs.PACKAGE }}
     permissions:
-      contents: read
+      contents: read            # Required to clone the repo.
+      actions: write           # Required to upload the plugin build artifact.
 
     steps:
       - name: Checkout
@@ -112,7 +113,8 @@ jobs:
     timeout-minutes: 60
     needs: build
     permissions:
-      contents: read
+      contents: read            # Required to clone the repo.
+      actions: write           # Required to download the build artifact and upload Playwright reports.
 
     steps:
       - name: Checkout

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -13,8 +13,8 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    # Repository dispatch uses secrets.WEBHOOK_TOKEN; the job does not use GITHUB_TOKEN against this repo.
+    permissions: {}
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -13,6 +13,7 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Repository dispatch uses secrets.WEBHOOK_TOKEN; the job does not use GITHUB_TOKEN against this repo.
     permissions: {}
     steps:

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -21,7 +21,9 @@ jobs:
     name: On Push
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read            # Required to clone the repo.
+      pull-requests: write      # Required for github-script to create/update PR comments with artifact links.
+      actions: write           # Required to upload the plugin build artifact.
     if: ${{ github.repository == 'newfold-labs/wp-plugin-bluehost' }}
     steps:
 

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -20,6 +20,7 @@ jobs:
   build:
     name: On Push
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read            # Required to clone the repo.
       pull-requests: write      # Required for github-script to create/update PR comments with artifact links.

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -20,6 +20,7 @@ jobs:
   build:
     name: On Release
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: write             # Required to checkout with persist-credentials and upload release assets with gh.
     steps:

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -21,7 +21,7 @@ jobs:
     name: On Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write             # Required to checkout with persist-credentials and upload release assets with gh.
     steps:
 
       - name: Checkout

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -28,7 +28,7 @@ jobs:
   lint:
     name: Scan & lint workflow files
     permissions:
-      security-events: write
-      actions: read
-      contents: read
+      security-events: write   # Required for SARIF or code scanning uploads from the reusable workflow.
+      actions: read           # Required for the reusable workflow to read workflow definitions.
+      contents: read          # Required for the reusable workflow to clone this repo.
     uses: newfold-labs/workflows/.github/workflows/reusable-workflow-lint.yml@main

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -27,6 +27,7 @@ permissions: {}
 jobs:
   lint:
     name: Scan & lint workflow files
+    timeout-minutes: 30
     permissions:
       security-events: write   # Required for SARIF or code scanning uploads from the reusable workflow.
       actions: read           # Required for the reusable workflow to read workflow definitions.

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -27,7 +27,6 @@ permissions: {}
 jobs:
   lint:
     name: Scan & lint workflow files
-    timeout-minutes: 30
     permissions:
       security-events: write   # Required for SARIF or code scanning uploads from the reusable workflow.
       actions: read           # Required for the reusable workflow to read workflow definitions.


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 22 (`auto-translate.yml`, `cloudflare-clear-cache.yml`, `codecoverage-cleanup.yml`, `codecoverage-main.yml`, `create-milestones.yml`, `delete-release.yml`, `deploy-and-test.yml`, `eslint.yml`, `i18n-crowdin-download.yml`, `i18n-crowdin-upload.yml`, `lint.yml`, `newfold-prepare-release.yml`, `performance-cron.yml`, `playground-cleanup.yml`, `playground-preview.yml`, `playwright-matrix.yml`, `playwright-tests-beta.yml`, `playwright-tests.yml`, `satis-webhook.yml`, `upload-artifact-on-push.yml`, `upload-asset-on-release.yml`, `workflow-lint.yml`) |
| Branch | `add/scoped-workflow-permissions` (already existed — commits appended locally) |
| Permissions commit | `3c5ce2e2` |
| Timeouts commit | `dce59de3` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `playground-preview.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-cleanup.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| delete-release.yml | 1 job was missing an explicit job-level `permissions` directive | delete | `permissions: {}` [3] |
| cloudflare-clear-cache.yml | 1 job was missing an explicit job-level `permissions` directive | clear-cache | `permissions: {}` [3] |
| performance-cron.yml | 1 job was missing an explicit job-level `permissions` directive | visit-site | `permissions: {}` [3] |
| codecoverage-main.yml | 1 job was missing an explicit job-level `permissions` directive | get-repo-name | `permissions: {}` [3] |
| upload-artifact-on-push.yml | 1 job was missing scoped permissions for PR commenting and artifact upload | build | `pull-requests: write`, `actions: write` (in addition to existing `contents: read`) [3] |
| playground-preview.yml | 1 job was missing `actions` scopes needed for artifact maintenance around Pages deploy | playground-preview | `actions: read`, `actions: write` (plus aligned inline comments on existing scopes) [2] |
| playground-cleanup.yml | 1 job was missing artifact download scope for `actions/download-artifact` with `github-token` | cleanup-preview | `actions: read` (plus aligned inline comments on existing scopes) [3] |
| deploy-and-test.yml | 1 job was missing artifact upload scope | deploy | `actions: write` (plus aligned inline comment on existing `contents: read`) [3] |
| playwright-tests.yml | 2 jobs were missing artifact scopes | build | `actions: write` [3] |
| playwright-tests.yml | 2 jobs were missing artifact scopes | test | `actions: write` [2] |
| playwright-tests-beta.yml | 1 job was missing artifact upload scope | test | `actions: write` [3] |
| playwright-matrix.yml | 3 jobs needed permission tightening/expansion | should-run-matrix | `permissions: {}` (replacing unnecessary `contents: read`) [3] |
| playwright-matrix.yml | 3 jobs needed permission tightening/expansion | test | `actions: write` [3] |
| playwright-matrix.yml | 3 jobs needed permission tightening/expansion | matrix-summary | `actions: read` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `satis-webhook.yml` :: `webhook`: BEFORE `contents: write` -> AFTER `permissions: {}` -- `peter-evans/repository-dispatch` uses `secrets.WEBHOOK_TOKEN`, not `GITHUB_TOKEN`, and there is no checkout/GitHub API use with the workflow token -- [3] |
| 2 | `codecoverage-main.yml` :: (workflow default): BEFORE `permissions: contents: read` at workflow level -> AFTER top-level `permissions: {}` + job-specific grants on callable jobs -- aligns with required default-deny pattern and avoids workflow-wide implicit grants -- [3] |
| 3 | `create-milestones.yml` :: `create-milestone`: BEFORE `issues: write` + `contents: read` -> AFTER `issues: write` -- job does not checkout the repository; milestone creation uses the Issues API with `GITHUB_TOKEN` -- [3] |
| 4 | `playwright-matrix.yml` :: `should-run-matrix`: BEFORE `contents: read` -> AFTER `permissions: {}` -- job reads only workflow event inputs/outputs in bash; no `actions/checkout` and no GitHub API calls -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| upload-asset-on-release.yml | build | `45` | release packaging, dependency install, zip creation, and `gh release upload` routinely need more than a few minutes; caps runaway builds without changing any pre-existing timeouts elsewhere. |
| upload-artifact-on-push.yml | build | `45` | mirrors the release build workload minus release upload; prevents stuck dependency/build steps from burning minutes indefinitely. |
| satis-webhook.yml | webhook | `10` | webhook dispatch is short; a small cap catches hung runners or network stalls quickly. |
| playground-preview.yml | playground-preview | `45` | Pages deploy + plugin build can be slow; generous but bounded limit for a multi-step preview pipeline. |
| playground-cleanup.yml | cleanup-preview | `30` | artifact download, repack, and Pages redeploy can vary; a moderate cap limits wedged deploy steps. |
| deploy-and-test.yml | deploy | `60` | SCP/SSH deploy plus Cypress smoke test polling needs headroom beyond typical lint jobs. |
| lint.yml | phpcs | `30` | PHPCS over a plugin-sized tree and Composer setup fits comfortably under a 30-minute ceiling. |
| eslint.yml | ESLint | `30` | `npm ci` + JS lint is usually fast; 30 minutes bounds rare hangs. |
| workflow-lint.yml | lint | `30` | reusable workflow scan should complete quickly; cap prevents indefinite runs on parser/tool failures. |
| codecoverage-main.yml | get-repo-name | `5` | single echo step; minimal cap. |
| codecoverage-main.yml | codecoverage | `120` | reusable coverage matrix + Pages commit can be long-running; uses a higher ceiling without modifying any pre-existing timeouts in other workflows. |
| codecoverage-cleanup.yml | get-merged-pr-commits | `10` | `gh api` commit listing should be quick; prevents stuck API calls from running unbounded. |
| codecoverage-cleanup.yml | cleanup-on-merge | `30` | reusable cleanup touching `gh-pages` history may take meaningful time. |
| codecoverage-cleanup.yml | cleanup-on-branch-delete | `30` | same rationale as merge cleanup; branch-delete pruning can be non-trivial. |
| codecoverage-cleanup.yml | cleanup-scheduled | `30` | scheduled pruning/squash operations warrant the same guardrail as other cleanup callers. |
| cloudflare-clear-cache.yml | clear-cache | `10` | single purge request should finish fast; tight cap. |
| delete-release.yml | delete | `10` | single Cloudflare purge step; tight cap. |
| performance-cron.yml | visit-site | `15` | login + a few admin requests with sleeps; small multi-minute budget with margin. |
| auto-translate.yml | translate | `60` | reusable translation automation may branch/commit/PR; hour cap limits runaway scheduled/dispatch runs. |
| newfold-prepare-release.yml | prep-release | `60` | release prep reusable workflow can touch branches/PRs; hour cap is a reasonable upper bound. |
| i18n-crowdin-upload.yml | call-crowdin-upload-workflow | `60` | Crowdin upload reusable workflow may be slow; aligns with other i18n automation caps. |
| i18n-crowdin-download.yml | call-crowdin-workflow | `60` | Crowdin download + PR flow can be slow; same rationale as upload caller. |
| create-milestones.yml | create-milestone | `10` | single `curl` API call with date logic; should complete quickly. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Callable workflows in `newfold-labs/workflows` (`reusable-codecoverage*.yml`, `reusable-translations.yml`, `reusable-plugin-prep-release.yml`, Crowdin callers, `reusable-workflow-lint.yml`) were not fully audited line-by-line; permissions on the caller jobs were chosen to match typical `GITHUB_TOKEN` needs (Pages/PRs/contents) but should be confirmed against upstream workflow changes over time. [2] |
| 2 | Jobs using `actions: write` where the workflow both downloads and uploads artifacts (notably `playwright-tests` :: `test`) assume GitHub’s `actions: write` scope is sufficient for artifact downloads in the same job; if GitHub ever enforces stricter separation, split permissions across jobs or verify with the Actions team/docs. [2] |
| 3 | `actions/configure-pages@v6` is invoked with `secrets.GITHUB_TOKEN` and `enablement: true`; if Pages enablement ever requires additional token scopes in your org/repo policy, revisit `pages`/`administration` requirements against current GitHub documentation. [2] |


