### PR TITLE
Replace Strauss with Mozart for wordpress/mcp-adapter namespace prefixing

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -43,10 +43,17 @@ vendor/newfold-labs/*/*.config.js
 vendor/newfold-labs/*/LICENSE
 vendor/newfold-labs/*/*.yml
 
-# Add wordpress/mcp-adapter rules vendor and vendor-prefixex
+# Add wordpress/mcp-adapter rules vendor and vendor-prefixed
 wordpress/mcp-adapter/.*
 wordpress/mcp-adapter/*.lock
 wordpress/mcp-adapter/*.json
 wordpress/mcp-adapter/*.md
 wordpress/mcp-adapter/tests
 wordpress/mcp-adapter/docs
+
+# Add wordpress/php-mcp-schema rules vendor and vendor-prefixed
+php-mcp-schema/.*
+php-mcp-schema/*.lock
+php-mcp-schema/*.json
+php-mcp-schema/*.md
+php-mcp-schema/tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Composer
 /vendor
 /vendor-prefixed
-bin/strauss.phar
+bin/mozart.phar
 
 #node_modules
 /node_modules

--- a/bin/mozart
+++ b/bin/mozart
@@ -3,10 +3,26 @@
 /**
  * Mozart PHAR wrapper.
  *
- * The Mozart PHAR stub uses Phar::mapPhar('') which registers the archive
- * under an empty alias, but the internal entry point tries to load files via
- * phar://mozart.phar/... The Phar::loadPhar() call below pre-registers the
- * archive under that alias so the internal references resolve correctly.
+ * Handles two issues with the Mozart PHAR distribution:
+ *
+ * 1. PHP version guard: Mozart requires PHP 8.1+. Workflows that install
+ *    Composer deps under PHP 7.4 (e.g. the PHPCS lint job) don't need the
+ *    vendor-prefixed output, so we exit 0 silently rather than crashing.
+ *
+ * 2. PHAR alias bug: The PHAR stub calls Phar::mapPhar('') (empty alias) but
+ *    the internal entry point references phar://mozart.phar/... Phar::loadPhar()
+ *    pre-registers the archive under that alias so the references resolve.
  */
-Phar::loadPhar(__DIR__ . DIRECTORY_SEPARATOR . 'mozart.phar', 'mozart.phar');
+if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+    exit(0);
+}
+
+$pharPath = __DIR__ . DIRECTORY_SEPARATOR . 'mozart.phar';
+
+if (!file_exists($pharPath)) {
+    fwrite(STDERR, 'Error: ' . $pharPath . ' not found. Run composer run ensure-mozart first.' . PHP_EOL);
+    exit(1);
+}
+
+Phar::loadPhar($pharPath, 'mozart.phar');
 require 'phar://mozart.phar/bin/mozart';

--- a/bin/mozart
+++ b/bin/mozart
@@ -1,0 +1,12 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Mozart PHAR wrapper.
+ *
+ * The Mozart PHAR stub uses Phar::mapPhar('') which registers the archive
+ * under an empty alias, but the internal entry point tries to load files via
+ * phar://mozart.phar/... The Phar::loadPhar() call below pre-registers the
+ * archive under that alias so the internal references resolve correctly.
+ */
+Phar::loadPhar(__DIR__ . DIRECTORY_SEPARATOR . 'mozart.phar', 'mozart.phar');
+require 'phar://mozart.phar/bin/mozart';

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -22,7 +22,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload_packages.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload_packages.php';
 }
 
-// Composer autoloader (includes prefixed packages via Strauss modification)
+// Composer autoloader (includes prefixed packages via PSR-4 autoload mapping)
 if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
 	require __DIR__ . '/vendor/autoload.php';
 } else {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
       "classmap_directory": "vendor-prefixed/",
       "classmap_prefix": "Bluehost_Plugin_",
       "packages": [
-        "wordpress/mcp-adapter"
+        "wordpress/mcp-adapter",
+        "wordpress/php-mcp-schema"
       ],
       "delete_vendor_directories": false
     }

--- a/composer.json
+++ b/composer.json
@@ -33,18 +33,19 @@
   },
   "extra": {
     "installer-name": "bluehost-wordpress-plugin",
-    "strauss": {
-      "target_directory": "vendor-prefixed",
-      "namespace_prefix": "Bluehost\\Plugin\\",
-      "delete_vendor_packages": false,
+    "mozart": {
+      "dep_namespace": "Bluehost\\Plugin\\",
+      "dep_directory": "vendor-prefixed/",
+      "classmap_prefix": "Bluehost_Plugin_",
       "packages": [
         "wordpress/mcp-adapter"
       ],
-      "exclude_from_copy": {
-        "file_patterns": [
-          "wordpress/mcp-adapter/tests"
-        ]
-      }
+      "delete_vendor_directories": false
+    }
+  },
+  "autoload": {
+    "psr-4": {
+      "Bluehost\\Plugin\\WP\\MCP\\": "vendor-prefixed/wordpress/mcp-adapter/includes/"
     }
   },
   "repositories": {
@@ -93,10 +94,10 @@
       "@i18n-json",
       "@i18n-php"
     ],
-    "ensure-strauss": "sh -c 'test -f ./bin/strauss.phar || (mkdir -p bin && curl -o bin/strauss.phar -L https://github.com/BrianHenryIE/strauss/releases/download/0.27.0/strauss.phar && chmod +x bin/strauss.phar)'",
+    "ensure-mozart": "sh -c 'test -f ./bin/mozart.phar || (mkdir -p bin && curl -o bin/mozart.phar -L https://github.com/coenjacobs/mozart/releases/download/1.1.6/mozart.phar && chmod +x bin/mozart.phar)'",
     "prefix-namespaces": [
-      "@ensure-strauss",
-      "@php bin/strauss.phar",
+      "@ensure-mozart",
+      "@php bin/mozart.phar compose",
       "@composer dump-autoload"
     ],
     "post-install-cmd": [
@@ -104,11 +105,6 @@
     ],
     "post-update-cmd": [
       "@prefix-namespaces"
-    ],
-    "post-autoload-dump": [
-      "@ensure-strauss",
-      "@php bin/strauss.phar include-autoloader",
-      "@php bin/strauss.phar"
     ],
     "test": [
       "codecept run wpunit"
@@ -131,11 +127,10 @@
     "i18n-json": "Generate new language .json files.",
     "i18n-ci-pre": "Command for CI to run before generating language files.",
     "i18n-ci-post": "Command for CI to run after generating language files.",
-    "ensure-strauss": "Ensure Strauss PHAR exists and is executable (downloads if missing).",
-    "prefix-namespaces": "Prefix namespaces for the plugin.",
+    "ensure-mozart": "Ensure Mozart PHAR exists and is executable (downloads if missing).",
+    "prefix-namespaces": "Prefix namespaces for the plugin using Mozart.",
     "post-install-cmd": "Command to run after installing the plugin.",
     "post-update-cmd": "Command to run after updating the plugin.",
-    "post-autoload-dump": "Command to run after dumping the autoloader.",
     "test": "Run tests.",
     "test-coverage": "Run tests with coverage, merge coverage and create HTML report."
   },

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "mozart": {
       "dep_namespace": "Bluehost\\Plugin\\",
       "dep_directory": "vendor-prefixed/",
+      "classmap_directory": "vendor-prefixed/",
       "classmap_prefix": "Bluehost_Plugin_",
       "packages": [
         "wordpress/mcp-adapter"
@@ -97,7 +98,7 @@
     "ensure-mozart": "sh -c 'test -f ./bin/mozart.phar || (mkdir -p bin && curl -o bin/mozart.phar -L https://github.com/coenjacobs/mozart/releases/download/1.1.6/mozart.phar && chmod +x bin/mozart.phar)'",
     "prefix-namespaces": [
       "@ensure-mozart",
-      "@php bin/mozart.phar compose",
+      "@php bin/mozart compose",
       "@composer dump-autoload"
     ],
     "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
   },
   "autoload": {
     "psr-4": {
-      "Bluehost\\Plugin\\WP\\MCP\\": "vendor-prefixed/wordpress/mcp-adapter/includes/"
+      "Bluehost\\Plugin\\WP\\MCP\\": "vendor-prefixed/wordpress/mcp-adapter/includes/",
+      "Bluehost\\Plugin\\WP\\McpSchema\\": "vendor-prefixed/wordpress/php-mcp-schema/src/"
     }
   },
   "repositories": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf3d4e9cfde2494f13c1e9f691021c7c",
+    "content-hash": "4144b8ee9cfa01c5a7e420759d896790",
     "packages": [
         {
             "name": "colinmollenhour/credis",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ef5f5c2b6bdbf9af80447b9528ef887",
+    "content-hash": "911c31232705f8ebb447b9ec81402d43",
     "packages": [
         {
             "name": "colinmollenhour/credis",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4144b8ee9cfa01c5a7e420759d896790",
+    "content-hash": "5ef5f5c2b6bdbf9af80447b9528ef887",
     "packages": [
         {
             "name": "colinmollenhour/credis",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "911c31232705f8ebb447b9ec81402d43",
+    "content-hash": "58e2b3e43b0bd8fb930de8ce04480ca3",
     "packages": [
         {
             "name": "colinmollenhour/credis",


### PR DESCRIPTION
## Summary

- Replaces BrianHenryIE/Strauss with coenjacobs/Mozart (v1.1.6) for prefixing `wordpress/mcp-adapter` and its dependency `wordpress/php-mcp-schema`
- Prefixes `WP\MCP\` → `Bluehost\Plugin\WP\MCP\` and `WP\McpSchema\` → `Bluehost\Plugin\WP\McpSchema\` in `vendor-prefixed/`
- Mozart 1.1.6 requires PHP ^8.1; the `bin/mozart` wrapper silently exits 0 on PHP < 8.1 so PHPCS/codecoverage jobs (PHP 7.4) are unaffected
- Eliminates the `post-autoload-dump` hook by using standard Composer `autoload.psr-4` mappings instead of Strauss's proprietary `include-autoloader` command

## What changed

| File | Change |
|------|--------|
| `composer.json` | `extra.strauss` → `extra.mozart` (packages: mcp-adapter + php-mcp-schema); `autoload.psr-4` entries for both prefixed namespaces; `ensure-mozart`/`bin/mozart.phar` scripts; removed `post-autoload-dump` hook |
| `composer.lock` | Updated `content-hash` to match new `extra.mozart` config |
| `bin/mozart` | Committed PHP wrapper: pre-registers PHAR alias (works around Mozart PHAR alias bug), PHP 8.1+ guard for PHP 7.4 CI jobs |
| `.gitignore` | `bin/strauss.phar` → `bin/mozart.phar` |
| `.distignore` | Added exclusion rules for dev files of both mcp-adapter and php-mcp-schema |
| `bootstrap.php` | Updated comment only |

## How autoloading works now

**Before (Strauss):** Strauss's `include-autoloader` command modified `vendor/autoload.php` directly after every autoload dump via a `post-autoload-dump` hook.

**After (Mozart):** PSR-4 entries in `composer.json` map the prefixed namespaces to their `vendor-prefixed/` locations. Standard `composer dump-autoload` (called at the end of `prefix-namespaces`) picks this up natively — no hook needed.

| Namespace | Path |
|-----------|------|
| `Bluehost\Plugin\WP\MCP\` | `vendor-prefixed/wordpress/mcp-adapter/includes/` |
| `Bluehost\Plugin\WP\McpSchema\` | `vendor-prefixed/wordpress/php-mcp-schema/src/` |

## Mozart config notes

- `delete_vendor_directories: false` preserves the original `vendor/wordpress/mcp-adapter/` and `vendor/wordpress/php-mcp-schema/` alongside the prefixed copies (mirrors Strauss's `delete_vendor_packages: false`)
- Mozart PHAR is downloaded on-demand by the `ensure-mozart` script (same pattern as Strauss was), so it works with `composer install --no-dev` in CI without requiring Mozart as a Composer dependency
- The `bin/mozart` wrapper pre-registers the PHAR alias to work around a known Mozart PHAR stub bug, and silently skips on PHP < 8.1

## CI status

All checks pass: Build Plugin ✅ · Run PHP Code Sniffer ✅ · On Push ✅ · playground-preview ✅ · codecoverage (all PHP versions) ✅ · CodeQL ✅

**Playwright failures** (`wp-env start` exit code 1 on all matrix combinations) are a pre-existing infrastructure issue unrelated to this PR — PR #1281 (the release PR, with no Mozart changes) has the same Playwright failures on the same base commit.

## Test plan

- [ ] Run `composer install` locally and verify `vendor-prefixed/wordpress/mcp-adapter/includes/` and `vendor-prefixed/wordpress/php-mcp-schema/src/` are created with `Bluehost\Plugin\WP\MCP\` and `Bluehost\Plugin\WP\McpSchema\` namespaces respectively
- [ ] Verify `vendor/autoload.php` resolves both prefixed namespace classes after install
- [ ] Confirm `vendor/wordpress/mcp-adapter/` and `vendor/wordpress/php-mcp-schema/` still exist (`delete_vendor_directories: false`)

https://claude.ai/code/session_01JUvFjmTwDxXHX8Y7mEULtT