### PR TITLE
Add wp-env install diagnostics

### DIFF
--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -173,6 +173,8 @@ jobs:
       - name: Verify WordPress is ready
         run: |
           echo "Verifying WordPress is ready..."
+          pwd
+          ls -la .wp-env*
           npx wp-env run cli wp core version
           echo "WordPress is ready!"
 

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -164,7 +164,11 @@ jobs:
         with:
           timeout_minutes: 4
           max_attempts: 3
-          command: npx wp-env start --debug
+          command: |
+            pwd
+            ls -la .wp-env*
+            npx wp-env start --debug
+            npx wp-env run cli wp core version
 
       - name: Verify WordPress is ready
         run: |

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -187,6 +187,8 @@ jobs:
       - name: Verify WordPress is ready
         run: |
           echo "Verifying WordPress is ready..."
+          pwd
+          ls -la .wp-env*
           npx wp-env run cli wp core version
           echo "WordPress is ready!"
 

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -178,7 +178,11 @@ jobs:
         with:
           timeout_minutes: 4
           max_attempts: 3
-          command: npx wp-env start --debug
+          command: |
+            pwd
+            ls -la .wp-env*
+            npx wp-env start --debug
+            npx wp-env run cli wp core version
 
       - name: Verify WordPress is ready
         run: |


### PR DESCRIPTION
## Summary
- expand retry-wrapped WordPress install commands with cwd and .wp-env file diagnostics
- verify wp-env can run WP-CLI immediately after start in the same retry command

## Why
The Playwright workflows are seeing wp-env report that the environment is not initialized in the follow-up verification step, even after the install step reports success. Running the first WP-CLI verification inside the same retry command should show whether the issue is within wp-env startup/config resolution or something that changes between steps.

## Testing
- Not run locally; workflow-only diagnostics change.