### PR TITLE
Fix wpCli() silently dropping timeout/failOnNonZeroExit options

### DIFF
--- a/tests/playwright/global-setup.js
+++ b/tests/playwright/global-setup.js
@@ -54,7 +54,8 @@ async function globalSetup(config) {
       'wordpress-seo/wp-seo.php',
     ];
     for (const plugin of extraPlugins) {
-      wordpress.wpCli(`plugin delete ${plugin}`, {
+      // Awaited so cleanup finishes deleting plugins before tests start.
+      await wordpress.wpCli(`plugin delete ${plugin}`, {
         failOnNonZeroExit: false,
       });
     }

--- a/tests/playwright/helpers/wordpress.mjs
+++ b/tests/playwright/helpers/wordpress.mjs
@@ -60,22 +60,30 @@ async function isPluginActive(page, pluginSlug) {
 
 /**
  * Execute WordPress CLI command
- * 
+ *
  * @param {string} command - WP-CLI command to execute
+ * @param {Object} options - Execution options
+ * @param {number} options.timeout - Kill the command if it runs longer than this (ms)
+ * @param {boolean} options.failOnNonZeroExit - Throw instead of returning an error string (default: false)
  * @returns {string|number} - Output string if available, 0 for success, or error info.
  */
-async function wpCli(command) {
+async function wpCli(command, options = {}) {
+  const { timeout, failOnNonZeroExit = false } = options;
   utils.fancyLog(`🔧 WP-CLI command: ${command}`);
   try {
     const output = execSync(`npx wp-env run cli wp ${command}`, {
       cwd: process.env.PLUGIN_DIR || process.cwd(),
       encoding: 'utf-8', // auto convert Buffer to string
       stdio: ['pipe', 'pipe', 'pipe'], // capture stdout/stderr
+      ...(timeout ? { timeout } : {}),
     });
 
     // If output is empty, just return 0 for success
     return output.trim() ? output.trim() : 0;
   } catch (err) {
+    if (failOnNonZeroExit) {
+      throw err;
+    }
     // err.status = exit code
     // err.stdout / err.stderr may have useful info
     if (err.stderr) {

--- a/tests/playwright/helpers/wordpress.mjs
+++ b/tests/playwright/helpers/wordpress.mjs
@@ -66,6 +66,7 @@ async function isPluginActive(page, pluginSlug) {
  * @param {number} options.timeout - Kill the command if it runs longer than this (ms)
  * @param {boolean} options.failOnNonZeroExit - Throw instead of returning an error string (default: false)
  * @returns {string|number} - Output string if available, 0 for success, or error info.
+ * @throws {Error} When failOnNonZeroExit is true and the command exits non-zero; error.message is prefixed with the command.
  */
 async function wpCli(command, options = {}) {
   const { timeout, failOnNonZeroExit = false } = options;
@@ -75,14 +76,15 @@ async function wpCli(command, options = {}) {
       cwd: process.env.PLUGIN_DIR || process.cwd(),
       encoding: 'utf-8', // auto convert Buffer to string
       stdio: ['pipe', 'pipe', 'pipe'], // capture stdout/stderr
-      ...(timeout ? { timeout } : {}),
+      ...(timeout !== undefined ? { timeout } : {}),
     });
 
     // If output is empty, just return 0 for success
     return output.trim() ? output.trim() : 0;
   } catch (err) {
     if (failOnNonZeroExit) {
-      throw err;
+      const detail = err.stderr ? err.stderr.toString().trim() : err.message;
+      throw new Error(`wp ${command}: ${detail}`);
     }
     // err.status = exit code
     // err.stdout / err.stderr may have useful info


### PR DESCRIPTION
## Summary

Companion fix to [newfold-labs/wp-module-coming-soon#292](https://github.com/newfold-labs/wp-module-coming-soon/pull/292), which fixes the coming-soon module's Playwright E2E failures in the "Bluehost Build and Test" CI jobs (root cause: a WooCommerce install/uninstall lifecycle in that module's tests was fataling an unrelated companion plugin in the shared brand-plugin test environment).

While investigating, found that `wordpress.mjs`'s `wpCli(command)` never accepted a second argument, even though every call site in this test suite already passes one:

- `global-setup.js`: `wordpress.wpCli(\`plugin delete ${plugin}\`, { failOnNonZeroExit: false })`
- wp-module-coming-soon's Playwright helpers: `wordpress.wpCli('plugin install woocommerce --activate', { timeout: 15000 })`, etc.

The options object was silently discarded:
- `timeout` was never passed to `execSync`, so wp-cli calls had no cap and could hang indefinitely.
- `failOnNonZeroExit` was a no-op — `wpCli()` always swallowed errors and returned a string, so the `try/catch` blocks callers wrote around `installWooCommerce()` etc. were dead code that could never trigger.

## Changes

- `wpCli(command, options = {})` now applies `options.timeout` to the underlying `execSync` call, and throws (instead of swallowing) when `options.failOnNonZeroExit` is `true`. Default behavior (no options passed) is unchanged, so existing bare calls (e.g. in `newfold.mjs`) aren't affected.
- `global-setup.js`'s plugin-cleanup loop now `await`s each `wpCli()` call — it was previously firing all the deletions without waiting, so cleanup could still be in flight when tests started.

## Test plan

- [ ] CI: Playwright workflows pass on this PR
- [x] `node --check` on both edited files
- [x] Confirmed no other caller relies on the previous (always-swallow) default behavior


---
_Generated by [Claude Code](https://claude.ai/code/session_016SMeiLMysC9rZ488fAKLJD)_