### PR TITLE
Raise PHP memory_limit in wp-env to fix Playwright CI memory exhaustion

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,7 +6,9 @@
     "WP_DEBUG_DISPLAY": false,
     "WP_ENVIRONMENT_TYPE": "local",
     "FS_METHOD": "direct",
-    "AUTOMATIC_UPDATER_DISABLED": true
+    "AUTOMATIC_UPDATER_DISABLED": true,
+    "WP_MEMORY_LIMIT": "512M",
+    "WP_MAX_MEMORY_LIMIT": "512M"
   },
   "phpVersion": "8.1",
   "plugins": [

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,6 +12,7 @@ The project uses **Playwright** for end-to-end tests in the browser. Tests run a
 
 - **Config file:** **`playwright.config.mjs`** (repository root).
 - **Port:** Taken from **`.wp-env.json`** (default dev port, e.g. 8882). In CI, **`.wp-env.override.json`** may be created by the workflow with a different core/phpVersion.
+- **PHP memory:** **`.wp-env.json`**'s `config` sets `WP_MEMORY_LIMIT`/`WP_MAX_MEMORY_LIMIT` to `512M` (above the container's 128M PHP default). This covers both wp-admin/front-end requests and WP-CLI invocations, since these constants are read on every WordPress bootstrap and raise `memory_limit` for the whole PHP process via `ini_set()`. Without this, a full Playwright run across every vendored module (100+ sequential tests, each driving wp-admin renders and WP-CLI calls against one long-lived wp-env instance) exhausts the default 128M and fails with `PHP Fatal error: Allowed memory size ... exhausted`.
 - **Projects:** Playwright “projects” (plugin + modules) are defined in **`tests/playwright/playwright-projects.json`**, which can be generated/updated by **`.github/scripts/generate-playwright-projects.mjs`** (run via `npm run test:playwright:update-projects`). The config merges in optional **`project-overrides.json`** per project.
 - **Global setup:** **`tests/playwright/global-setup.js`** runs before tests (e.g. sets permalink structure and flushes rewrite rules via WP-CLI in wp-env).
 


### PR DESCRIPTION
## Summary

- Raise `WP_MEMORY_LIMIT`/`WP_MAX_MEMORY_LIMIT` to `512M` in `.wp-env.json` (container default is 128M).
- Document the setting in `docs/testing.md`.

## Context

While investigating an unrelated, now-fixed Playwright bug (wp-module-coming-soon #292 / wp-plugin-bluehost #1343), once that bug was fixed, CI progressed further than it ever had before and hit a second, separate, pre-existing problem: PHP memory exhaustion in the test environment.

The job "Bluehost Dev Build and Test Playwright / Build and Test" (part of the reusable `module-plugin-test-playwright.yml` workflow in `newfold-labs/workflows`, triggered from `wp-module-coming-soon`'s `brand-plugin-test-playwright.yml`) failed with `debug.log` full of repeated entries like:

```
PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 10485760 bytes) in phar:///usr/local/bin/wp/vendor/wp-cli/php-cli-tools/lib/cli/Colors.php on line 21
PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 10485760 bytes) in /var/www/html/wp-content/plugins/wordpress-seo/src/integrations/front-end-integration.php on line 506
```

134217728 bytes = 128MB, the default `memory_limit` in the wp-env container's php.ini. These errors repeated dozens of times, hit from many different code paths (WP-CLI's own color-formatting library, WordPress core/plugin rendering, wp-admin file handling) — a `memory_limit` too low for the cumulative load of a full Playwright run (many sequential WP-CLI invocations plus page renders against one long-lived wp-env instance, across every vendored module in a single job).

This is not something the recent fix introduced — it's a pre-existing constraint in the test environment that was simply never reached before, because the job always failed earlier at the bug that's now fixed.

Evidence: [wp-module-coming-soon run 29363193976, job 87188270565](https://github.com/newfold-labs/wp-module-coming-soon/actions/runs/29363193976/job/87188270565).

## Why this fix

`WP_MEMORY_LIMIT`/`WP_MAX_MEMORY_LIMIT` are wp-config.php constants read on every WordPress bootstrap (`wp_initial_constants()` / `wp_raise_memory_limit()`), which raise `memory_limit` via `ini_set()` for the whole PHP process. Since `.wp-env.json`'s `config` values become wp-config constants, and both `.wp-env.override.json` files used in CI (this repo's own matrix workflow, and the reusable `module-plugin-test-playwright.yml`) only merge in `plugins`/`core`/`phpVersion` — never replacing `config` — this raises the ceiling everywhere wp-env is started from this repo's config: local dev, `playwright-tests.yml`, `playwright-matrix.yml`, and the reusable workflow used by module repos like `wp-module-coming-soon`.

This also fixes the WP-CLI failures (e.g. `Colors.php`), not just wp-admin ones: WP-CLI loads `wp-config.php` too, so the same `ini_set()` call raises the limit for the rest of that CLI process.

## Test plan

- [x] Verified `.wp-env.json` is valid JSON.
- [ ] Confirm the fix by re-running the affected Playwright workflow(s) and checking `debug.log` is clean of memory-exhaustion errors (tracking in follow-up; local Docker/network access wasn't available in the dev sandbox used to prepare this change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NXk3yTyYAcmE6jYFe62zoR)_