### PR TITLE
Update solutions module; e2e test infra fixes

### DIFF
--- a/.github/scripts/generate-playwright-projects.mjs
+++ b/.github/scripts/generate-playwright-projects.mjs
@@ -54,6 +54,12 @@ function getVendorModules() {
   return vendorModules.sort((a, b) => a.name.localeCompare(b.name));
 }
 
+// Modules whose specs toggle plugin activation state (e.g. deactivate the whole
+// plugin mid-test). Deferred to run last so a still-deactivated plugin can't be
+// caught mid-teardown by another module's test setup running sequentially after it.
+// https://github.com/newfold-labs/wp-plugin-bluehost/pull/1380
+const RUN_LAST_MODULES = ['wp-module-deactivation'];
+
 function generateProjects() {
   console.log('🔍 Playwright Projects Discovery:');
   const projects = [
@@ -67,30 +73,33 @@ function generateProjects() {
   const localModules = getLocalModules();
   const vendorModules = getVendorModules();
   const discoveredModules = new Set();
+  const deferredProjects = [];
+
+  const addModule = (module, projectName) => {
+    if (discoveredModules.has(module.name)) {
+      return;
+    }
+    discoveredModules.add(module.name);
+    const project = {
+      name: projectName,
+      testDir: `./${module.path}/tests/playwright/specs`,
+      testMatch: '*.spec.{js,mjs}',
+    };
+    if (RUN_LAST_MODULES.includes(module.name)) {
+      deferredProjects.push(project);
+    } else {
+      projects.push(project);
+    }
+  };
 
   // Add local modules first (they take precedence)
-  localModules.forEach(module => {
-    if (!discoveredModules.has(module.name)) {
-      projects.push({
-        name: `newfold-labs/${module.name}-local`,
-        testDir: `./${module.path}/tests/playwright/specs`,
-        testMatch: '*.spec.{js,mjs}',
-      });
-      discoveredModules.add(module.name);
-    }
-  });
+  localModules.forEach(module => addModule(module, `newfold-labs/${module.name}-local`));
 
   // Add vendor modules if no local version exists
-  vendorModules.forEach(module => {
-    if (!discoveredModules.has(module.name)) {
-      projects.push({
-        name: `newfold-labs/${module.name}`,
-        testDir: `./${module.path}/tests/playwright/specs`,
-        testMatch: '*.spec.{js,mjs}',
-      });
-      discoveredModules.add(module.name);
-    }
-  });
+  vendorModules.forEach(module => addModule(module, `newfold-labs/${module.name}`));
+
+  // Append run-last modules at the very end, in their original discovery order.
+  projects.push(...deferredProjects);
 
   console.log(`📁 Found ${projects.length} project(s):`);
   projects.forEach(p => {

--- a/.github/scripts/generate-playwright-projects.mjs
+++ b/.github/scripts/generate-playwright-projects.mjs
@@ -58,7 +58,7 @@ function getVendorModules() {
 // plugin mid-test). Deferred to run last so a still-deactivated plugin can't be
 // caught mid-teardown by another module's test setup running sequentially after it.
 // https://github.com/newfold-labs/wp-plugin-bluehost/pull/1380
-const RUN_LAST_MODULES = ['wp-module-deactivation'];
+const RUN_LAST_MODULES = new Set(['wp-module-deactivation']);
 
 function generateProjects() {
   console.log('🔍 Playwright Projects Discovery:');
@@ -85,7 +85,7 @@ function generateProjects() {
       testDir: `./${module.path}/tests/playwright/specs`,
       testMatch: '*.spec.{js,mjs}',
     };
-    if (RUN_LAST_MODULES.includes(module.name)) {
+    if (RUN_LAST_MODULES.has(module.name)) {
       deferredProjects.push(project);
     } else {
       projects.push(project);
@@ -100,6 +100,9 @@ function generateProjects() {
 
   // Append run-last modules at the very end, in their original discovery order.
   projects.push(...deferredProjects);
+  if (deferredProjects.length > 0) {
+    console.log(`⏭️  Deferring ${deferredProjects.length} project(s) to run last: ${deferredProjects.map(p => p.name).join(', ')}`);
+  }
 
   console.log(`📁 Found ${projects.length} project(s):`);
   projects.forEach(p => {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-  "core": "WordPress/WordPress#tags/7.0.1",
+  "core": "WordPress/WordPress#tags/7.0.2",
   "config": {
     "WP_DEBUG": true,
     "WP_DEBUG_LOG": true,

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,7 +6,9 @@
     "WP_DEBUG_DISPLAY": false,
     "WP_ENVIRONMENT_TYPE": "local",
     "FS_METHOD": "direct",
-    "AUTOMATIC_UPDATER_DISABLED": true
+    "AUTOMATIC_UPDATER_DISABLED": true,
+    "WP_MEMORY_LIMIT": "256M",
+    "WP_MAX_MEMORY_LIMIT": "256M"
   },
   "phpVersion": "8.1",
   "plugins": [

--- a/bluehost-wordpress-plugin.php
+++ b/bluehost-wordpress-plugin.php
@@ -15,7 +15,7 @@
  * Version:           4.17.2
  * Requires PHP:      7.4
  * Requires at least: 6.6
- * Tested up to:      7.0.1
+ * Tested up to:      7.0.2
  * Author:            Bluehost
  * Author URI:        https://bluehost.com
  * Text Domain:       wp-plugin-bluehost

--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
     "newfold-labs/wp-module-atomic": "^1.4.1",
     "newfold-labs/wp-module-coming-soon": "^2.2.9",
     "newfold-labs/wp-module-context": "^1.0.3",
-    "newfold-labs/wp-module-data": "^2.9.4",
+    "newfold-labs/wp-module-data": "^2.9.5",
     "newfold-labs/wp-module-deactivation": "^1.6.1",
     "newfold-labs/wp-module-ecommerce": "^2.3.9",
     "newfold-labs/wp-module-editor-chat": "1.0.9",

--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
     "newfold-labs/wp-module-atomic": "^1.4.1",
     "newfold-labs/wp-module-coming-soon": "^2.2.9",
     "newfold-labs/wp-module-context": "^1.0.3",
-    "newfold-labs/wp-module-data": "^2.9.5",
+    "newfold-labs/wp-module-data": "^2.9.4",
     "newfold-labs/wp-module-deactivation": "^1.6.1",
     "newfold-labs/wp-module-ecommerce": "^2.3.9",
     "newfold-labs/wp-module-editor-chat": "1.0.9",

--- a/composer.json
+++ b/composer.json
@@ -185,7 +185,7 @@
     "newfold-labs/wp-module-reset": "^1.0.2",
     "newfold-labs/wp-module-runtime": "^1.2.2",
     "newfold-labs/wp-module-secure-passwords": "^1.1.3",
-    "newfold-labs/wp-module-solutions": "^2.10.2",
+    "newfold-labs/wp-module-solutions": "^2.10.3",
     "newfold-labs/wp-module-sso": "^1.3.0",
     "newfold-labs/wp-module-staging": "^2.7.4",
     "wp-forge/wp-update-handler": "^1.0.2",

--- a/composer.json
+++ b/composer.json
@@ -177,7 +177,7 @@
     "newfold-labs/wp-module-migration": "^1.7.4",
     "newfold-labs/wp-module-next-steps": "^1.6.0",
     "newfold-labs/wp-module-notifications": "^1.8.3",
-    "newfold-labs/wp-module-onboarding": "^3.3.6",
+    "newfold-labs/wp-module-onboarding": "^3.3.7",
     "newfold-labs/wp-module-onboarding-data": "^1.2.25",
     "newfold-labs/wp-module-patterns": "^2.13.0",
     "newfold-labs/wp-module-performance": "^3.8.1",

--- a/composer.json
+++ b/composer.json
@@ -177,7 +177,7 @@
     "newfold-labs/wp-module-migration": "^1.7.4",
     "newfold-labs/wp-module-next-steps": "^1.6.0",
     "newfold-labs/wp-module-notifications": "^1.8.3",
-    "newfold-labs/wp-module-onboarding": "^3.3.7",
+    "newfold-labs/wp-module-onboarding": "^3.3.6",
     "newfold-labs/wp-module-onboarding-data": "^1.2.25",
     "newfold-labs/wp-module-patterns": "^2.13.0",
     "newfold-labs/wp-module-performance": "^3.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "195d978dbf28b8223f1c50c4a25eb6d1",
+    "content-hash": "5a43b1c721534a4d08814d1b76cef969",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -2955,35 +2955,35 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding",
-            "version": "3.3.7",
+            "version": "3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding.git",
-                "reference": "e2a34400552706173aaf8df4a3d897a0e9d29c81"
+                "reference": "bd901d8e549295f381279e69c2193a21c07f221c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/e2a34400552706173aaf8df4a3d897a0e9d29c81",
-                "reference": "e2a34400552706173aaf8df4a3d897a0e9d29c81",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/bd901d8e549295f381279e69c2193a21c07f221c",
+                "reference": "bd901d8e549295f381279e69c2193a21c07f221c",
                 "shasum": ""
             },
             "require": {
                 "mustache/mustache": "^2.14.2",
-                "newfold-labs/wp-module-install-checker": "^1.0.3",
-                "newfold-labs/wp-module-migration": "^1.7.2",
-                "newfold-labs/wp-module-patterns": "^2.13.0",
-                "newfold-labs/wp-module-survey": "^1.0.1",
-                "wp-cli/wp-config-transformer": "^1.4.5",
+                "newfold-labs/wp-module-facebook": "^1.3.3",
+                "newfold-labs/wp-module-migration": "^1.7.1",
+                "newfold-labs/wp-module-onboarding-data": "^1.2.23",
+                "newfold-labs/wp-module-patterns": "^2.10.3",
+                "wp-cli/wp-config-transformer": "^1.4.4",
                 "wp-forge/helpers": "^2.0"
             },
             "require-dev": {
-                "johnpbloch/wordpress": "7.0.0",
+                "johnpbloch/wordpress": "6.9.4",
                 "lucatume/wp-browser": "*",
-                "newfold-labs/wp-php-standards": "^1.2.6",
+                "newfold-labs/wp-php-standards": "^1.2.5",
                 "php": ">=7.4",
                 "phpunit/phpcov": "*",
                 "wp-cli/i18n-command": "^2.7.0",
-                "wp-phpunit/wp-phpunit": "^7.0.2",
+                "wp-phpunit/wp-phpunit": "^6.9.4",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "library",
@@ -3005,8 +3005,11 @@
                 "i18n-po": [
                     "vendor/bin/wp i18n update-po ./languages/wp-module-onboarding.pot ./languages"
                 ],
+                "i18n-mo": [
+                    "vendor/bin/wp i18n make-mo ./languages"
+                ],
                 "i18n-php": [
-                    "vendor/bin/wp i18n make-php ./languages --pretty-print"
+                    "vendor/bin/wp i18n make-php ./languages"
                 ],
                 "i18n-json": [
                     "find ./languages -type f -name \"*.po\" -print0 | xargs -0 -I {} sh -c 'name=$(basename \"$1\" .po); npx po2json languages/\"$name\".po languages/\"$name\"-nfd-onboarding.json -f jed1.x' -- {}"
@@ -3048,10 +3051,10 @@
             ],
             "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/3.3.7",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/3.3.6",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding/issues"
             },
-            "time": "2026-07-22T20:41:36+00:00"
+            "time": "2026-03-24T16:41:10+00:00"
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4e6f17654b8e0319bdfbf692abf54ea",
+    "content-hash": "c5f0f908432e682fc2ab21f94c1d8d71",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -3650,16 +3650,16 @@
         },
         {
             "name": "newfold-labs/wp-module-solutions",
-            "version": "2.10.2",
+            "version": "2.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-solutions.git",
-                "reference": "c47a150edbe2964bb420f106d6088aded0103f75"
+                "reference": "b616f315a07a28102385a8905293160a49946b66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-solutions/zipball/c47a150edbe2964bb420f106d6088aded0103f75",
-                "reference": "c47a150edbe2964bb420f106d6088aded0103f75",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-solutions/zipball/b616f315a07a28102385a8905293160a49946b66",
+                "reference": "b616f315a07a28102385a8905293160a49946b66",
                 "shasum": ""
             },
             "require": {
@@ -3734,10 +3734,10 @@
             ],
             "description": "A Newfold module that handles integration of WordPress Solutions Addon packages (content creator/ service / ecommerce) for BlueHost & HostGator customers",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-solutions/tree/2.10.2",
+                "source": "https://github.com/newfold-labs/wp-module-solutions/tree/2.10.3",
                 "issues": "https://github.com/newfold-labs/wp-module-solutions/issues"
             },
-            "time": "2026-06-22T12:07:34+00:00"
+            "time": "2026-07-22T22:24:11+00:00"
         },
         {
             "name": "newfold-labs/wp-module-sso",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5f0f908432e682fc2ab21f94c1d8d71",
+    "content-hash": "ed6450df618492b9104c332cd3018c22",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -1265,16 +1265,16 @@
         },
         {
             "name": "newfold-labs/wp-module-data",
-            "version": "2.9.4",
+            "version": "2.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-data.git",
-                "reference": "19144133e08e79c87f5aec6b72d26110b878b117"
+                "reference": "75633bc1055c45901aaaaf9308385bb2d2828f30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/19144133e08e79c87f5aec6b72d26110b878b117",
-                "reference": "19144133e08e79c87f5aec6b72d26110b878b117",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/75633bc1055c45901aaaaf9308385bb2d2828f30",
+                "reference": "75633bc1055c45901aaaaf9308385bb2d2828f30",
                 "shasum": ""
             },
             "require": {
@@ -1287,19 +1287,19 @@
                 "wpscholar/url": "^1.2.5"
             },
             "require-dev": {
-                "10up/wp_mock": "^1.1.0",
+                "10up/wp_mock": "^1.1.1",
                 "brianhenryie/composer-phpstorm": ">=0.4",
-                "johnpbloch/wordpress": ">=6.9.4",
+                "johnpbloch/wordpress": ">=7.0.2",
                 "kporras07/composer-symlinks": "^1.3",
                 "lucatume/wp-browser": "^3.7.8",
                 "newfold-labs/wp-php-standards": "^1.2.6",
                 "newfold-labs/wp-plugin-bluehost": "dev-latest-zip",
                 "phpunit/phpcov": "^8.2.1",
                 "wp-cli/i18n-command": "^2.7.3",
-                "wp-plugin/jetpack": "^15.8",
-                "wp-plugin/woocommerce": ">=10.6.2",
-                "wp-plugin/woocommerce-payments": "^10.7.1",
-                "wp-theme/twentytwentyfive": ">=1"
+                "wp-plugin/jetpack": "^16.0",
+                "wp-plugin/woocommerce": ">=10.9.4",
+                "wp-plugin/woocommerce-payments": "^10.9.0",
+                "wp-theme/twentytwentyfive": ">=1.5"
             },
             "type": "library",
             "extra": {
@@ -1391,10 +1391,10 @@
             ],
             "description": "Newfold Data Module",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.9.4",
+                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.9.5",
                 "issues": "https://github.com/newfold-labs/wp-module-data/issues"
             },
-            "time": "2026-05-15T15:38:23+00:00"
+            "time": "2026-07-22T22:33:25+00:00"
         },
         {
             "name": "newfold-labs/wp-module-deactivation",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1dfa98d2f84d8a9c8f73d6a060083946",
+    "content-hash": "195d978dbf28b8223f1c50c4a25eb6d1",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -1265,16 +1265,16 @@
         },
         {
             "name": "newfold-labs/wp-module-data",
-            "version": "2.9.5",
+            "version": "2.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-data.git",
-                "reference": "75633bc1055c45901aaaaf9308385bb2d2828f30"
+                "reference": "19144133e08e79c87f5aec6b72d26110b878b117"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/75633bc1055c45901aaaaf9308385bb2d2828f30",
-                "reference": "75633bc1055c45901aaaaf9308385bb2d2828f30",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/19144133e08e79c87f5aec6b72d26110b878b117",
+                "reference": "19144133e08e79c87f5aec6b72d26110b878b117",
                 "shasum": ""
             },
             "require": {
@@ -1287,19 +1287,19 @@
                 "wpscholar/url": "^1.2.5"
             },
             "require-dev": {
-                "10up/wp_mock": "^1.1.1",
+                "10up/wp_mock": "^1.1.0",
                 "brianhenryie/composer-phpstorm": ">=0.4",
-                "johnpbloch/wordpress": ">=7.0.2",
+                "johnpbloch/wordpress": ">=6.9.4",
                 "kporras07/composer-symlinks": "^1.3",
                 "lucatume/wp-browser": "^3.7.8",
                 "newfold-labs/wp-php-standards": "^1.2.6",
                 "newfold-labs/wp-plugin-bluehost": "dev-latest-zip",
                 "phpunit/phpcov": "^8.2.1",
                 "wp-cli/i18n-command": "^2.7.3",
-                "wp-plugin/jetpack": "^16.0",
-                "wp-plugin/woocommerce": ">=10.9.4",
-                "wp-plugin/woocommerce-payments": "^10.9.0",
-                "wp-theme/twentytwentyfive": ">=1.5"
+                "wp-plugin/jetpack": "^15.8",
+                "wp-plugin/woocommerce": ">=10.6.2",
+                "wp-plugin/woocommerce-payments": "^10.7.1",
+                "wp-theme/twentytwentyfive": ">=1"
             },
             "type": "library",
             "extra": {
@@ -1391,10 +1391,10 @@
             ],
             "description": "Newfold Data Module",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.9.5",
+                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.9.4",
                 "issues": "https://github.com/newfold-labs/wp-module-data/issues"
             },
-            "time": "2026-07-22T22:33:25+00:00"
+            "time": "2026-05-15T15:38:23+00:00"
         },
         {
             "name": "newfold-labs/wp-module-deactivation",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b513a9a4282381d68913c809107c2ff2",
+    "content-hash": "f4e6f17654b8e0319bdfbf692abf54ea",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -2955,35 +2955,35 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding",
-            "version": "3.3.6",
+            "version": "3.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding.git",
-                "reference": "bd901d8e549295f381279e69c2193a21c07f221c"
+                "reference": "e2a34400552706173aaf8df4a3d897a0e9d29c81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/bd901d8e549295f381279e69c2193a21c07f221c",
-                "reference": "bd901d8e549295f381279e69c2193a21c07f221c",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/e2a34400552706173aaf8df4a3d897a0e9d29c81",
+                "reference": "e2a34400552706173aaf8df4a3d897a0e9d29c81",
                 "shasum": ""
             },
             "require": {
                 "mustache/mustache": "^2.14.2",
-                "newfold-labs/wp-module-facebook": "^1.3.3",
-                "newfold-labs/wp-module-migration": "^1.7.1",
-                "newfold-labs/wp-module-onboarding-data": "^1.2.23",
-                "newfold-labs/wp-module-patterns": "^2.10.3",
-                "wp-cli/wp-config-transformer": "^1.4.4",
+                "newfold-labs/wp-module-install-checker": "^1.0.3",
+                "newfold-labs/wp-module-migration": "^1.7.2",
+                "newfold-labs/wp-module-patterns": "^2.13.0",
+                "newfold-labs/wp-module-survey": "^1.0.1",
+                "wp-cli/wp-config-transformer": "^1.4.5",
                 "wp-forge/helpers": "^2.0"
             },
             "require-dev": {
-                "johnpbloch/wordpress": "6.9.4",
+                "johnpbloch/wordpress": "7.0.0",
                 "lucatume/wp-browser": "*",
-                "newfold-labs/wp-php-standards": "^1.2.5",
+                "newfold-labs/wp-php-standards": "^1.2.6",
                 "php": ">=7.4",
                 "phpunit/phpcov": "*",
                 "wp-cli/i18n-command": "^2.7.0",
-                "wp-phpunit/wp-phpunit": "^6.9.4",
+                "wp-phpunit/wp-phpunit": "^7.0.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "library",
@@ -3005,11 +3005,8 @@
                 "i18n-po": [
                     "vendor/bin/wp i18n update-po ./languages/wp-module-onboarding.pot ./languages"
                 ],
-                "i18n-mo": [
-                    "vendor/bin/wp i18n make-mo ./languages"
-                ],
                 "i18n-php": [
-                    "vendor/bin/wp i18n make-php ./languages"
+                    "vendor/bin/wp i18n make-php ./languages --pretty-print"
                 ],
                 "i18n-json": [
                     "find ./languages -type f -name \"*.po\" -print0 | xargs -0 -I {} sh -c 'name=$(basename \"$1\" .po); npx po2json languages/\"$name\".po languages/\"$name\"-nfd-onboarding.json -f jed1.x' -- {}"
@@ -3051,10 +3048,10 @@
             ],
             "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/3.3.6",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/3.3.7",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding/issues"
             },
-            "time": "2026-03-24T16:41:10+00:00"
+            "time": "2026-07-22T20:41:36+00:00"
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,20 +66,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@ampproject/remapping": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/@ariakit/components": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.7.tgz",
@@ -203,12 +189,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -217,9 +203,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.26.8",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-            "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -227,22 +213,22 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-            "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.25.7",
-                "@babel/generator": "^7.25.7",
-                "@babel/helper-compilation-targets": "^7.25.7",
-                "@babel/helper-module-transforms": "^7.25.7",
-                "@babel/helpers": "^7.25.7",
-                "@babel/parser": "^7.25.7",
-                "@babel/template": "^7.25.7",
-                "@babel/traverse": "^7.25.7",
-                "@babel/types": "^7.25.7",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -304,15 +290,15 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-            "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.27.0",
-                "@babel/types": "^7.27.0",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
             },
             "engines": {
@@ -333,14 +319,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
-            "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.26.8",
-                "@babel/helper-validator-option": "^7.25.9",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -436,6 +422,15 @@
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-member-expression-to-functions": {
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
@@ -451,28 +446,28 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-            "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-            "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9",
-                "@babel/traverse": "^7.25.9"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -495,9 +490,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-            "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -555,27 +550,27 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-            "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -598,26 +593,26 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
-            "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.0",
-                "@babel/types": "^7.27.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-            "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1425,16 +1420,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
-            "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+            "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.25.9",
-                "@babel/helper-plugin-utils": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9",
-                "@babel/traverse": "^7.25.9"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2191,45 +2186,45 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-            "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/parser": "^7.27.0",
-                "@babel/types": "^7.27.0"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-            "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.27.0",
-                "@babel/parser": "^7.27.0",
-                "@babel/template": "^7.27.0",
-                "@babel/types": "^7.27.0",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-            "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -4224,32 +4219,30 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-            "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -4273,9 +4266,9 @@
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -4432,9 +4425,9 @@
             }
         },
         "node_modules/@nodable/entities": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+            "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
             "dev": true,
             "funding": [
                 {
@@ -5948,14 +5941,14 @@
             }
         },
         "node_modules/@php-wasm/cli-util": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.20.tgz",
-            "integrity": "sha512-zO02i+SpPUF/3O9/JEAmideDiwICzGcoCKssleavwv9sDRr9j7nIokuG9u97T37QgrHX0sap9BGTzZ9C6cgG6w==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.46.tgz",
+            "integrity": "sha512-m3bDR/PyiiJzdRMwUBfbXG2VwB+OhrAcCAmLbjB3dkkPxJ7mSCnNbInDY43fkpUuiqTCzamrrgt/tpGdtLPTiQ==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/util": "3.1.20",
-                "fast-xml-parser": "^5.5.1",
+                "@php-wasm/util": "3.1.46",
+                "fast-xml-parser": "^5.8.0",
                 "jsonc-parser": "3.3.1"
             },
             "engines": {
@@ -5971,9 +5964,9 @@
             "license": "MIT"
         },
         "node_modules/@php-wasm/logger": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.20.tgz",
-            "integrity": "sha512-uewkiBJKohKTqcUT3oyi+ijwhW4DiSP9E1wqXdMbIwfFw3ZKKQWuqS0+TsLMt6imR6wTir1jwZwacizVjE6Lcg==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.46.tgz",
+            "integrity": "sha512-PfnDq5ammh5FXxkGX1TGEck9gmW3i76IvBCqtX4D45xnSBIuCeu8uf2oWuty2j/c8wTEO8vyRDdvCj5oow7bXw==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "engines": {
@@ -5982,32 +5975,42 @@
             }
         },
         "node_modules/@php-wasm/node": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.20.tgz",
-            "integrity": "sha512-g1MoBRBit223c3s9WFw6mj0StIfxI7joIwRn1q8lZZCaxRTJ3lTKSsK4IPrXGQcGBPHu+cYWzJ+xiFdGwKmmkw==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.46.tgz",
+            "integrity": "sha512-PHmV+nAQka6l4SB7GyAbkneqnyhTvfjhC9jArKNF7sUDGwVDdvvu0Fh5JRY4G1Eam3Z5gopD4YwDySJCfdq8LA==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/cli-util": "3.1.20",
-                "@php-wasm/logger": "3.1.20",
-                "@php-wasm/node-7-4": "3.1.20",
-                "@php-wasm/node-8-0": "3.1.20",
-                "@php-wasm/node-8-1": "3.1.20",
-                "@php-wasm/node-8-2": "3.1.20",
-                "@php-wasm/node-8-3": "3.1.20",
-                "@php-wasm/node-8-4": "3.1.20",
-                "@php-wasm/node-8-5": "3.1.20",
-                "@php-wasm/universal": "3.1.20",
-                "@php-wasm/util": "3.1.20",
-                "@wp-playground/common": "3.1.20",
-                "express": "4.22.0",
-                "fast-xml-parser": "^5.5.1",
+                "@php-wasm/cli-util": "3.1.46",
+                "@php-wasm/logger": "3.1.46",
+                "@php-wasm/node-5-2": "3.1.46",
+                "@php-wasm/node-7-4": "3.1.46",
+                "@php-wasm/node-8-0": "3.1.46",
+                "@php-wasm/node-8-1": "3.1.46",
+                "@php-wasm/node-8-2": "3.1.46",
+                "@php-wasm/node-8-3": "3.1.46",
+                "@php-wasm/node-8-4": "3.1.46",
+                "@php-wasm/node-8-5": "3.1.46",
+                "@php-wasm/universal": "3.1.46",
+                "@php-wasm/util": "3.1.46",
                 "fs-ext-extra-prebuilt": "2.2.7",
-                "ini": "4.1.2",
-                "jsonc-parser": "3.3.1",
                 "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0",
-                "yargs": "17.7.2"
+                "ws": "8.21.0"
+            },
+            "engines": {
+                "node": ">=20.10.0",
+                "npm": ">=10.2.3"
+            }
+        },
+        "node_modules/@php-wasm/node-5-2": {
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.46.tgz",
+            "integrity": "sha512-J77WzhYO0cBPDktaoBZ7y980knhN4/nghhVjv7fj57fWYA1m5ZbCGOqcZUys7sQm/vdahcpaU27vqUCHXBrbZw==",
+            "dev": true,
+            "license": "GPL-2.0-or-later",
+            "dependencies": {
+                "@php-wasm/universal": "3.1.46",
+                "wasm-feature-detect": "1.8.0"
             },
             "engines": {
                 "node": ">=20.10.0",
@@ -6015,370 +6018,114 @@
             }
         },
         "node_modules/@php-wasm/node-7-4": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.20.tgz",
-            "integrity": "sha512-SMSuSBpIERYb7GN5YbePLJjjqClys5jIQrO+s8tJJj2VLkEDzHlyS5CmYWsvkynbzAz5FEBOWtYoVTlVhWzLKw==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.46.tgz",
+            "integrity": "sha512-HC3li/qX49C5FJKff0X+uewMFzVI5IE2hBhTb0DsJGn5xME1F7W6WoZ4hjrKkIGkjIbATPmiDGspUoHrvmX83A==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/universal": "3.1.20",
-                "ini": "4.1.2",
-                "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0"
+                "@php-wasm/universal": "3.1.46",
+                "wasm-feature-detect": "1.8.0"
             },
             "engines": {
                 "node": ">=20.10.0",
                 "npm": ">=10.2.3"
-            }
-        },
-        "node_modules/@php-wasm/node-7-4/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@php-wasm/node-8-0": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.20.tgz",
-            "integrity": "sha512-6SdYDZUupzLwMMf/wI+B02H+a9mQcB3tKUuAyVHRz3SzPo3AQcHJCUlASR7G1sP+mQ+F6D6kOTwQdIfgtfcNHA==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.46.tgz",
+            "integrity": "sha512-insUfErssn1NpQ3DNpRYOgTRf89/R7j2b7svMOU05J2sb6v3UFSmkKIR8MndxgvgW5uQhvyQyGHVa79B93ykiA==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/universal": "3.1.20",
-                "ini": "4.1.2",
-                "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0"
+                "@php-wasm/universal": "3.1.46",
+                "wasm-feature-detect": "1.8.0"
             },
             "engines": {
                 "node": ">=20.10.0",
                 "npm": ">=10.2.3"
-            }
-        },
-        "node_modules/@php-wasm/node-8-0/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@php-wasm/node-8-1": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.20.tgz",
-            "integrity": "sha512-DURvgZLVkDBst+KF/O34A8SM9zdHXKUgafQzc2udxa4uOM+oQ8MHdx9UMOPI9O+T7vSIzDBWHRCwoCHQGa4Cmg==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.46.tgz",
+            "integrity": "sha512-nPvpbUqAwHmrUSbaLFHgUZDuvyAfo1OfMjLXdgqMjn5nb2QnjlKota4afA/2F6j2WxzjdiXZxro1bSa5fB+OlQ==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/universal": "3.1.20",
-                "ini": "4.1.2",
-                "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0"
+                "@php-wasm/universal": "3.1.46",
+                "wasm-feature-detect": "1.8.0"
             },
             "engines": {
                 "node": ">=20.10.0",
                 "npm": ">=10.2.3"
-            }
-        },
-        "node_modules/@php-wasm/node-8-1/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@php-wasm/node-8-2": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.20.tgz",
-            "integrity": "sha512-ov2r4ZvKAoDa2EdgNo3+jgA0XRwTt08AG8iRsMaqlFBuhCgr7NdaKjonXwoHIg41hfntL/y5cNL4iZlv85eMaw==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.46.tgz",
+            "integrity": "sha512-CyDiEZjDBQMsrEnNN+1ZOXcgB4K5bYZ8lmYYDdmGnto7U4nAyzPOT+LydkRoLd27AqabJqnimwkryduDptbE/A==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/universal": "3.1.20",
-                "ini": "4.1.2",
-                "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0"
+                "@php-wasm/universal": "3.1.46",
+                "wasm-feature-detect": "1.8.0"
             },
             "engines": {
                 "node": ">=20.10.0",
                 "npm": ">=10.2.3"
-            }
-        },
-        "node_modules/@php-wasm/node-8-2/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@php-wasm/node-8-3": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.20.tgz",
-            "integrity": "sha512-d44tJF0PhuQQEt8svtwOnryqnUTyUchsUGziTzw1aaN5C+/pJF3D5L7Gmu9PQn0RXyZua9fpMzuWrIfuWGCiHQ==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.46.tgz",
+            "integrity": "sha512-ZSH1rPvVuhIYJkGE/GRkQtv7RoQlO0IMWkHLJGt+JrTeaDxxm8Mv/F0H67MrA80q43zzNdNQaUEPn+ZrN/GSwg==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/universal": "3.1.20",
-                "ini": "4.1.2",
-                "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0"
+                "@php-wasm/universal": "3.1.46",
+                "wasm-feature-detect": "1.8.0"
             },
             "engines": {
                 "node": ">=20.10.0",
                 "npm": ">=10.2.3"
-            }
-        },
-        "node_modules/@php-wasm/node-8-3/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@php-wasm/node-8-4": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.20.tgz",
-            "integrity": "sha512-f6JjuMdkE3SmK78kqkzXX38tiKKdgeuu/nmpQkUgHDcsnVfwtpgsF23o9XBqIGmkmFOAQ4fivn2oYS+ar/EU+g==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.46.tgz",
+            "integrity": "sha512-4Wl7hwp6p3m0jaliIMYJz8cIY7obJF3HKxoHKxOcVllKgP+cSr5c/iwFcgYct4goC9sP7wr/xQGeClGQ51aP0A==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/universal": "3.1.20",
-                "ini": "4.1.2",
-                "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0"
+                "@php-wasm/universal": "3.1.46",
+                "wasm-feature-detect": "1.8.0"
             },
             "engines": {
                 "node": ">=20.10.0",
                 "npm": ">=10.2.3"
-            }
-        },
-        "node_modules/@php-wasm/node-8-4/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@php-wasm/node-8-5": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.20.tgz",
-            "integrity": "sha512-6GLFSHEzCIFhKWm77bx6fI4+ffxwLh+zQO4U7TNLmU3ZW2Yb6LnsTXn+uWAv6tqUVk5+bXQRgF4bPUd+Jksf1Q==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.46.tgz",
+            "integrity": "sha512-ndL2jnGCVVwhAmHPgo3tWZ+I6q2Flz6OWbbQwGVBQcXqqPdZuVHh+0Gb5KTTn1cGtCErdpL+3ysLwN7tk5LqUA==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/universal": "3.1.20",
-                "ini": "4.1.2",
-                "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0"
+                "@php-wasm/universal": "3.1.46",
+                "wasm-feature-detect": "1.8.0"
             },
             "engines": {
                 "node": ">=20.10.0",
                 "npm": ">=10.2.3"
             }
         },
-        "node_modules/@php-wasm/node-8-5/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@php-wasm/node/node_modules/cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@php-wasm/node/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/@php-wasm/node/node_modules/express": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-            "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
-                "content-disposition": "~0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "~0.7.1",
-                "cookie-signature": "~1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "~1.3.1",
-                "fresh": "~0.5.2",
-                "http-errors": "~2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "~2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "~0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "~0.19.0",
-                "serve-static": "~1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "~2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/@php-wasm/node/node_modules/jsonc-parser": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@php-wasm/node/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@php-wasm/node/node_modules/path-to-regexp": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@php-wasm/node/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6398,13 +6145,13 @@
             }
         },
         "node_modules/@php-wasm/progress": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.20.tgz",
-            "integrity": "sha512-URARh4wAb+I8p9SJ1gMPov89wEWd2VIe7ikR6kHdKbKWUNsPfyrvuhqDKF+2sMiQWGjLlZenckDRePoMwyrAJw==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.46.tgz",
+            "integrity": "sha512-WmmgEm6yz322M3pzgAUjxckyhpVxr2WWlHyVYDyaMZWU6UIDUHfiRZRPzADohNyYvV3g0/zMNaDGmxz+TTXwQQ==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/logger": "3.1.20"
+                "@php-wasm/logger": "3.1.46"
             },
             "engines": {
                 "node": ">=20.10.0",
@@ -6412,9 +6159,9 @@
             }
         },
         "node_modules/@php-wasm/scopes": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.20.tgz",
-            "integrity": "sha512-ia5Vdb8vcqDauewjJJTzklmBgnmxNi5NjUOGltAWzOveecfj8H8v+gdgX4/CDryCgu92EYhCu/Ko1a3x7eO5Vg==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.46.tgz",
+            "integrity": "sha512-WkH55sjdRSE+FIljMy97ScPIhGLbdVZOSmwXJkctEvmflZqtDIS4fOs9qRKj2dV+Nh4ewyfcWUSf5tTMJnyAuA==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "engines": {
@@ -6423,26 +6170,26 @@
             }
         },
         "node_modules/@php-wasm/stream-compression": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.20.tgz",
-            "integrity": "sha512-nAOA7wb0GKtMD2kcgVworVT5wrgmfSS3b5cacM0YUPb4z2uHhmBjhBQTQKVkTc1p3BrzUQpILqrnxVsRVuahNQ==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.46.tgz",
+            "integrity": "sha512-+oUw4CPX52FgYXEh5C+MgJAg7Cy5OeaVuh7HnQR6oxb69nU63/r8tHTLV/WrWRyjBYh321uJzLV7Gg29qmiUtg==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/util": "3.1.20"
+                "@php-wasm/util": "3.1.46"
             }
         },
         "node_modules/@php-wasm/universal": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.20.tgz",
-            "integrity": "sha512-ptpup7608diKaq7wVQBkx1BQjpVI+nXRyE/1eg9XehtMCSwTBsW2ykLJfTVwVem9yRGGUNdCdvYlpOesknrGOA==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.46.tgz",
+            "integrity": "sha512-sx0KyN5kcsCMzwy+XJAyoOukSA5TEZYd0LK3l9kRP3I0CSd5h6JItkf5eZ42WltB+wD+aTRdqSwc/Mvkc7qBjQ==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/logger": "3.1.20",
-                "@php-wasm/progress": "3.1.20",
-                "@php-wasm/stream-compression": "3.1.20",
-                "@php-wasm/util": "3.1.20",
+                "@php-wasm/logger": "3.1.46",
+                "@php-wasm/progress": "3.1.46",
+                "@php-wasm/stream-compression": "3.1.46",
+                "@php-wasm/util": "3.1.46",
                 "ini": "4.1.2"
             },
             "engines": {
@@ -6451,9 +6198,9 @@
             }
         },
         "node_modules/@php-wasm/util": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.20.tgz",
-            "integrity": "sha512-5Ad14Y6BO38bWzvSdYvmljREY7iVlkEp9auzh8KtQ8OeymQPvzAafdHuS0dsO5Cv61KC01LQfMZzhn9QlDIeJg==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.46.tgz",
+            "integrity": "sha512-Yh9HNbx+rB2R1tScUvvAsbJVIB7msjWceWYogyR2YvAOqlDL0ymZyaQ65+K3QcHh/8HostTRwwgQh5oK4DLDrA==",
             "dev": true,
             "engines": {
                 "node": ">=20.10.0",
@@ -6461,15 +6208,14 @@
             }
         },
         "node_modules/@php-wasm/web-service-worker": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.20.tgz",
-            "integrity": "sha512-/S3O+QdJ4b88+HMzim1B+drxrYf4NCpAyU+6hbzhN2fL/yiqsGvXVWWGUeegU1dWGicvXA50vlgsfbh1lWMCMA==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.46.tgz",
+            "integrity": "sha512-GwQzZbEnF+7a3wGqDaMCdbsCuDUdOvTyHAul40TbSATUZ1FdUVagI94pMMMQtYCCxQFnEuO/WxzwDKJJ3hpaug==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/scopes": "3.1.20",
-                "@php-wasm/universal": "3.1.20",
-                "ini": "4.1.2"
+                "@php-wasm/scopes": "3.1.46",
+                "@php-wasm/universal": "3.1.46"
             },
             "engines": {
                 "node": ">=20.10.0",
@@ -6477,23 +6223,15 @@
             }
         },
         "node_modules/@php-wasm/xdebug-bridge": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.20.tgz",
-            "integrity": "sha512-fSLYKwxd7CsdRxcsEyX5EiN9d0DvMnO8c2+a5UiH81Zlilue1M85i1ut6w8DwIk388usnqMeuLCdBLpO4IZ/xQ==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.46.tgz",
+            "integrity": "sha512-no8Hr5Uw6EcwKjwUbBHlu2gTCZ5v4szeQT1AKjDYazM8Mur1AtaL2/q8X0IB8Hy4NDV/Jxgt33lxCh1n8XnnWA==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/logger": "3.1.20",
-                "@php-wasm/node": "3.1.20",
-                "@php-wasm/universal": "3.1.20",
-                "@wp-playground/common": "3.1.20",
-                "express": "4.22.0",
-                "fast-xml-parser": "^5.5.1",
-                "fs-ext-extra-prebuilt": "2.2.7",
-                "ini": "4.1.2",
-                "jsonc-parser": "3.3.1",
-                "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0",
+                "@php-wasm/logger": "3.1.46",
+                "@php-wasm/universal": "3.1.46",
+                "ws": "8.21.0",
                 "xml2js": "0.6.2",
                 "yargs": "17.7.2"
             },
@@ -6505,98 +6243,10 @@
                 "npm": ">=10.2.3"
             }
         },
-        "node_modules/@php-wasm/xdebug-bridge/node_modules/cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@php-wasm/xdebug-bridge/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/@php-wasm/xdebug-bridge/node_modules/express": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-            "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
-                "content-disposition": "~0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "~0.7.1",
-                "cookie-signature": "~1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "~1.3.1",
-                "fresh": "~0.5.2",
-                "http-errors": "~2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "~2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "~0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "~0.19.0",
-                "serve-static": "~1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "~2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/@php-wasm/xdebug-bridge/node_modules/jsonc-parser": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@php-wasm/xdebug-bridge/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@php-wasm/xdebug-bridge/node_modules/path-to-regexp": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@php-wasm/xdebug-bridge/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7003,6 +6653,23 @@
                 "@opentelemetry/semantic-conventions": "^1.34.0"
             }
         },
+        "node_modules/@simple-git/args-pathspec": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+            "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@simple-git/argv-parser": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+            "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-git/args-pathspec": "^1.0.3"
+            }
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -7297,10 +6964,20 @@
             }
         },
         "node_modules/@svgr/core/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -7407,10 +7084,20 @@
             }
         },
         "node_modules/@svgr/plugin-svgo/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -7569,9 +7256,9 @@
             }
         },
         "node_modules/@types/aws-lambda": {
-            "version": "8.10.161",
-            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
-            "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
+            "version": "8.10.162",
+            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
+            "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
             "dev": true,
             "license": "MIT"
         },
@@ -9809,44 +9496,21 @@
             }
         },
         "node_modules/@wp-playground/blueprints": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.20.tgz",
-            "integrity": "sha512-+JeN1eWQGhNExlsnMhprPPUOeptYyn0JFTParIoYIQxv+0K3gXYDdOyeQiIBubJa2+usBn9b1VRXI76wgpv3gw==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.46.tgz",
+            "integrity": "sha512-3X6AtHU8FyK4XtQKBN6lS3HKWykLl9TQ+t+iM3c6XYtQJatENoKmsZjv/JFgKEo6c+JP4ma8CsEdb6PqwJYEuw==",
             "dev": true,
             "dependencies": {
-                "@php-wasm/logger": "3.1.20",
-                "@php-wasm/node": "3.1.20",
-                "@php-wasm/progress": "3.1.20",
-                "@php-wasm/scopes": "3.1.20",
-                "@php-wasm/stream-compression": "3.1.20",
-                "@php-wasm/universal": "3.1.20",
-                "@php-wasm/util": "3.1.20",
-                "@php-wasm/web-service-worker": "3.1.20",
-                "@wp-playground/common": "3.1.20",
-                "@wp-playground/storage": "3.1.20",
-                "@wp-playground/wordpress": "3.1.20",
-                "@zip.js/zip.js": "2.7.57",
-                "ajv": "8.12.0",
-                "async-lock": "1.4.1",
-                "clean-git-ref": "2.0.1",
-                "crc-32": "1.2.2",
-                "diff3": "0.0.4",
-                "express": "4.22.0",
-                "fast-xml-parser": "^5.5.1",
-                "fs-ext-extra-prebuilt": "2.2.7",
-                "ignore": "5.3.2",
-                "ini": "4.1.2",
-                "jsonc-parser": "3.3.1",
-                "minimisted": "2.0.1",
-                "octokit": "3.1.2",
-                "pako": "1.0.10",
-                "pify": "2.3.0",
-                "readable-stream": "3.6.2",
-                "sha.js": "2.4.12",
-                "simple-get": "4.0.1",
-                "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0",
-                "yargs": "17.7.2"
+                "@php-wasm/logger": "3.1.46",
+                "@php-wasm/progress": "3.1.46",
+                "@php-wasm/stream-compression": "3.1.46",
+                "@php-wasm/universal": "3.1.46",
+                "@php-wasm/util": "3.1.46",
+                "@php-wasm/web-service-worker": "3.1.46",
+                "@wp-playground/common": "3.1.46",
+                "@wp-playground/storage": "3.1.46",
+                "@wp-playground/wordpress": "3.1.46",
+                "ajv": "8.18.0"
             },
             "engines": {
                 "node": ">=20.10.0",
@@ -9854,278 +9518,49 @@
             }
         },
         "node_modules/@wp-playground/blueprints/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fast-deep-equal": "^3.1.1",
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
                 "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
+                "require-from-string": "^2.0.2"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@wp-playground/blueprints/node_modules/cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@wp-playground/blueprints/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/@wp-playground/blueprints/node_modules/express": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-            "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
-                "content-disposition": "~0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "~0.7.1",
-                "cookie-signature": "~1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "~1.3.1",
-                "fresh": "~0.5.2",
-                "http-errors": "~2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "~2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "~0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "~0.19.0",
-                "serve-static": "~1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "~2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/@wp-playground/blueprints/node_modules/jsonc-parser": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/blueprints/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/blueprints/node_modules/path-to-regexp": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/blueprints/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@wp-playground/blueprints/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@wp-playground/cli": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.20.tgz",
-            "integrity": "sha512-OPzpl6movUV3hslIVwlx9YINE0wgc/2S51E1mZdwznjvqQUV1QjdmyWBJ7Ep9fsDKCCnlEaxnlQiWNGuhf/mfw==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.46.tgz",
+            "integrity": "sha512-rn20w2Fp72wwnnOB+UyvvZ9zRx1dsPXC7KSMgJFEvoLNEVdp3bXcvyv8U5XZpeAPqkZB7nhMJDwOhcLR4SqVOA==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/cli-util": "3.1.20",
-                "@php-wasm/logger": "3.1.20",
-                "@php-wasm/node": "3.1.20",
-                "@php-wasm/progress": "3.1.20",
-                "@php-wasm/universal": "3.1.20",
-                "@php-wasm/util": "3.1.20",
-                "@php-wasm/xdebug-bridge": "3.1.20",
-                "@wp-playground/blueprints": "3.1.20",
-                "@wp-playground/common": "3.1.20",
-                "@wp-playground/storage": "3.1.20",
-                "@wp-playground/tools": "3.1.20",
-                "@wp-playground/wordpress": "3.1.20",
-                "@zip.js/zip.js": "2.7.57",
-                "ajv": "8.12.0",
-                "async-lock": "1.4.1",
-                "clean-git-ref": "2.0.1",
-                "crc-32": "1.2.2",
-                "diff3": "0.0.4",
-                "express": "4.22.0",
-                "fast-xml-parser": "^5.5.1",
-                "fs-ext-extra-prebuilt": "2.2.7",
+                "@php-wasm/cli-util": "3.1.46",
+                "@php-wasm/logger": "3.1.46",
+                "@php-wasm/node": "3.1.46",
+                "@php-wasm/progress": "3.1.46",
+                "@php-wasm/universal": "3.1.46",
+                "@php-wasm/util": "3.1.46",
+                "@php-wasm/xdebug-bridge": "3.1.46",
+                "@wp-playground/blueprints": "3.1.46",
+                "@wp-playground/common": "3.1.46",
+                "@wp-playground/storage": "3.1.46",
+                "@wp-playground/tools": "3.1.46",
+                "@wp-playground/wordpress": "3.1.46",
+                "express": "4.22.2",
                 "fs-extra": "11.1.1",
-                "ignore": "5.3.2",
-                "ini": "4.1.2",
-                "jsonc-parser": "3.3.1",
-                "minimisted": "2.0.1",
-                "octokit": "3.1.2",
-                "pako": "1.0.10",
-                "pify": "2.3.0",
-                "readable-stream": "3.6.2",
-                "sha.js": "2.4.12",
-                "simple-get": "4.0.1",
                 "tmp-promise": "3.0.3",
                 "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0",
-                "xml2js": "0.6.2",
                 "yargs": "17.7.2"
             },
             "bin": {
                 "wp-playground-cli": "wp-playground.js"
-            }
-        },
-        "node_modules/@wp-playground/cli/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/@wp-playground/cli/node_modules/cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@wp-playground/cli/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/@wp-playground/cli/node_modules/express": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-            "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
-                "content-disposition": "~0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "~0.7.1",
-                "cookie-signature": "~1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "~1.3.1",
-                "fresh": "~0.5.2",
-                "http-errors": "~2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "~2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "~0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "~0.19.0",
-                "serve-static": "~1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "~2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/@wp-playground/cli/node_modules/fs-extra": {
@@ -10143,74 +9578,15 @@
                 "node": ">=14.14"
             }
         },
-        "node_modules/@wp-playground/cli/node_modules/jsonc-parser": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/cli/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/cli/node_modules/path-to-regexp": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/cli/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@wp-playground/cli/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@wp-playground/common": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.20.tgz",
-            "integrity": "sha512-F9RAsltz67xzDL9HcJHsVt89w4sUe1ccCioxjEBSkHrDcxb5vw2oSRuFteFkMFZwl1WdXy0c/AtC+xbf0M6C3A==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.46.tgz",
+            "integrity": "sha512-MZ4ZSsh9GG7oHYhe38T+9uW6mGDvlwoH8IyJWNJN/PgH5SPPUHnP1CtmiMTl/p+sOf4ELf4A/REa16OtoJ83Qg==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/universal": "3.1.20",
-                "@php-wasm/util": "3.1.20",
-                "ini": "4.1.2"
+                "@php-wasm/universal": "3.1.46",
+                "@php-wasm/util": "3.1.46"
             },
             "engines": {
                 "node": ">=20.10.0",
@@ -10218,375 +9594,52 @@
             }
         },
         "node_modules/@wp-playground/storage": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.20.tgz",
-            "integrity": "sha512-fchpDqFMOgJAkxTcTbiCDHaigo7DU+s3QInoBmwfYYxJtGzBxCYTjPkEnG2HEJXwLjDpHu2mnFF6ZZm1Cg3BuQ==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.46.tgz",
+            "integrity": "sha512-NH9Tkt4WBpFtgZ6KrUkPJygsjzbbN1UVQ7IBawQba4dB2mjx2HNznUT3qyCPpQL6Vn8dO9YFHQ4fRLxvWbeCpw==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/stream-compression": "3.1.20",
-                "@php-wasm/universal": "3.1.20",
-                "@php-wasm/util": "3.1.20",
+                "@php-wasm/stream-compression": "3.1.46",
+                "@php-wasm/universal": "3.1.46",
+                "@php-wasm/util": "3.1.46",
                 "@zip.js/zip.js": "2.7.57",
-                "async-lock": "^1.4.1",
-                "clean-git-ref": "^2.0.1",
-                "crc-32": "^1.2.0",
-                "diff3": "0.0.3",
-                "ignore": "^5.1.4",
-                "ini": "4.1.2",
-                "minimisted": "^2.0.0",
+                "isomorphic-git": "1.37.6",
                 "octokit": "3.1.2",
                 "pako": "^1.0.10",
-                "pify": "^4.0.1",
-                "readable-stream": "^3.4.0",
-                "sha.js": "^2.4.9",
-                "simple-get": "^4.0.1"
-            }
-        },
-        "node_modules/@wp-playground/storage/node_modules/diff3": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-            "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/storage/node_modules/pify": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@wp-playground/storage/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
+                "sha.js": "2.4.12"
             }
         },
         "node_modules/@wp-playground/tools": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.20.tgz",
-            "integrity": "sha512-KH2qiwVmItaTxIfmyk1yOhI23yDgbgMSNSVrOTV+cmepOqzIl29FZWD4XTWWANWDG8hxnvnN4o82EhrWmefoBw==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.46.tgz",
+            "integrity": "sha512-rSov51gL1HnxgXkhw2TO9EIuldj3aaBYPGQ+MQsmF5adV5CSYdw+wq2ZJS/wpUiePyv6gvdZJTWaVqbjINFc2w==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@wp-playground/blueprints": "3.1.20",
-                "@zip.js/zip.js": "2.7.57",
-                "ajv": "8.12.0",
-                "async-lock": "1.4.1",
-                "clean-git-ref": "2.0.1",
-                "crc-32": "1.2.2",
-                "diff3": "0.0.4",
-                "express": "4.22.0",
-                "fast-xml-parser": "^5.5.1",
-                "fs-ext-extra-prebuilt": "2.2.7",
-                "ignore": "5.3.2",
-                "ini": "4.1.2",
-                "jsonc-parser": "3.3.1",
-                "minimisted": "2.0.1",
-                "octokit": "3.1.2",
-                "pako": "1.0.10",
-                "pify": "2.3.0",
-                "readable-stream": "3.6.2",
-                "sha.js": "2.4.12",
-                "simple-get": "4.0.1",
-                "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0",
-                "yargs": "17.7.2"
+                "@wp-playground/blueprints": "3.1.46"
             },
             "engines": {
                 "node": ">=20.10.0",
                 "npm": ">=10.2.3"
-            }
-        },
-        "node_modules/@wp-playground/tools/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/@wp-playground/tools/node_modules/cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@wp-playground/tools/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/@wp-playground/tools/node_modules/express": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-            "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
-                "content-disposition": "~0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "~0.7.1",
-                "cookie-signature": "~1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "~1.3.1",
-                "fresh": "~0.5.2",
-                "http-errors": "~2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "~2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "~0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "~0.19.0",
-                "serve-static": "~1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "~2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/@wp-playground/tools/node_modules/jsonc-parser": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/tools/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/tools/node_modules/path-to-regexp": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/tools/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@wp-playground/tools/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@wp-playground/wordpress": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.20.tgz",
-            "integrity": "sha512-Ya3LQ6NNpE92AwWye51j5EMpMxJuAZ4BRo5e0F2ZVELw/WAE7GT/N5rFoLp6C+H4hZH9UjlNG/6Xi9L+wkB/ag==",
+            "version": "3.1.46",
+            "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.46.tgz",
+            "integrity": "sha512-QGzxrSmlm3ewiyU6NB2VDMgqZ5ZPuuSsPg4YkRnQrX489v0ohqCLp/jUe/+5nvXKGNg4KnR/37QrerEtLryXcw==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@php-wasm/logger": "3.1.20",
-                "@php-wasm/node": "3.1.20",
-                "@php-wasm/universal": "3.1.20",
-                "@php-wasm/util": "3.1.20",
-                "@wp-playground/common": "3.1.20",
-                "express": "4.22.0",
-                "fast-xml-parser": "^5.5.1",
-                "fs-ext-extra-prebuilt": "2.2.7",
-                "ini": "4.1.2",
-                "jsonc-parser": "3.3.1",
-                "wasm-feature-detect": "1.8.0",
-                "ws": "8.18.0",
-                "yargs": "17.7.2"
+                "@php-wasm/logger": "3.1.46",
+                "@php-wasm/universal": "3.1.46",
+                "@php-wasm/util": "3.1.46",
+                "@wp-playground/common": "3.1.46",
+                "zstddec": "^0.2.0"
             },
             "engines": {
                 "node": ">=20.10.0",
                 "npm": ">=10.2.3"
-            }
-        },
-        "node_modules/@wp-playground/wordpress/node_modules/cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@wp-playground/wordpress/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/@wp-playground/wordpress/node_modules/express": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-            "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
-                "content-disposition": "~0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "~0.7.1",
-                "cookie-signature": "~1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "~1.3.1",
-                "fresh": "~0.5.2",
-                "http-errors": "~2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "~2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "~0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "~0.19.0",
-                "serve-static": "~1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "~2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/@wp-playground/wordpress/node_modules/jsonc-parser": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/wordpress/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/wordpress/node_modules/path-to-regexp": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@wp-playground/wordpress/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@xobotyi/scrollbar-width": {
@@ -10628,6 +9681,19 @@
             "deprecated": "Use your platform's native atob() and btoa() methods instead",
             "dev": true,
             "license": "BSD-3-Clause"
+        },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
         },
         "node_modules/accepts": {
             "version": "1.3.8",
@@ -10713,9 +9779,9 @@
             }
         },
         "node_modules/adm-zip": {
-            "version": "0.5.16",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-            "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+            "version": "0.5.18",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+            "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10902,6 +9968,19 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/anynum": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+            "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/are-docs-informative": {
             "version": "0.0.2",
@@ -11546,6 +10625,27 @@
                 "bare-path": "^3.0.0"
             }
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/baseline-browser-mapping": {
             "version": "2.10.43",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
@@ -11607,9 +10707,9 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.4",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-            "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+            "version": "1.20.6",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+            "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11621,7 +10721,7 @@
                 "http-errors": "~2.0.1",
                 "iconv-lite": "~0.4.24",
                 "on-finished": "~2.4.1",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "raw-body": "~2.5.3",
                 "type-is": "~1.6.18",
                 "unpipe": "~1.0.0"
@@ -11705,9 +10805,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11777,6 +10877,31 @@
             "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
         },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
@@ -13533,9 +12658,9 @@
             }
         },
         "node_modules/diff3": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
-            "integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+            "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
             "dev": true,
             "license": "MIT"
         },
@@ -14387,9 +13512,9 @@
             }
         },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14566,9 +13691,9 @@
             }
         },
         "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14703,9 +13828,9 @@
             }
         },
         "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15007,6 +14132,16 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/eventemitter3": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -15061,15 +14196,15 @@
             }
         },
         "node_modules/express": {
-            "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-            "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+            "version": "4.22.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
+                "body-parser": "~1.20.5",
                 "content-disposition": "~0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "~0.7.1",
@@ -15088,7 +14223,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "~0.19.0",
@@ -15232,9 +14367,9 @@
             "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
         },
         "node_modules/fast-uri": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "dev": true,
             "funding": [
                 {
@@ -15249,9 +14384,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-            "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+            "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
             "dev": true,
             "funding": [
                 {
@@ -15261,13 +14396,14 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "path-expression-matcher": "^1.1.3"
+                "path-expression-matcher": "^1.6.2",
+                "xml-naming": "^0.3.0"
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-            "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+            "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
             "dev": true,
             "funding": [
                 {
@@ -15277,10 +14413,12 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@nodable/entities": "^2.1.0",
-                "fast-xml-builder": "^1.1.5",
-                "path-expression-matcher": "^1.5.0",
-                "strnum": "^2.2.3"
+                "@nodable/entities": "^3.0.0",
+                "fast-xml-builder": "^1.2.0",
+                "is-unsafe": "^2.0.0",
+                "path-expression-matcher": "^1.6.2",
+                "strnum": "^2.4.1",
+                "xml-naming": "^0.3.0"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -16059,9 +15197,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16134,6 +15272,7 @@
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -16810,9 +15949,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+            "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16894,6 +16033,27 @@
                 "postcss": "^8.1.0"
             }
         },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -16918,9 +16078,9 @@
             }
         },
         "node_modules/ignore-walk/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16959,9 +16119,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
             "dev": true,
             "license": "MIT"
         },
@@ -17635,6 +16795,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-unsafe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+            "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -17716,6 +16889,69 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isomorphic-git": {
+            "version": "1.37.6",
+            "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.37.6.tgz",
+            "integrity": "sha512-qr1NFCPsVTZ6YGqTXw0CzamnsHyH9QQ1OTEfeXIweSljRUMzuHFCJdUn0wc6OcjtTDns6knxjPb7N6LmJeftOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "async-lock": "^1.4.1",
+                "clean-git-ref": "^2.0.1",
+                "crc-32": "^1.2.0",
+                "diff3": "0.0.3",
+                "ignore": "^5.1.4",
+                "minimisted": "^2.0.0",
+                "pako": "^1.0.10",
+                "pify": "^4.0.1",
+                "readable-stream": "^4.0.0",
+                "sha.js": "^2.4.12",
+                "simple-get": "^4.0.1"
+            },
+            "bin": {
+                "isogit": "cli.cjs"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/isomorphic-git/node_modules/pify": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/isomorphic-git/node_modules/readable-stream": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+            "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/isomorphic-git/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/istanbul-lib-coverage": {
@@ -19352,14 +18588,14 @@
             }
         },
         "node_modules/launch-editor": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.10.0.tgz",
-            "integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+            "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "picocolors": "^1.0.0",
-                "shell-quote": "^1.8.1"
+                "picocolors": "^1.1.1",
+                "shell-quote": "^1.8.4"
             }
         },
         "node_modules/legacy-javascript": {
@@ -19813,9 +19049,9 @@
             "license": "Python-2.0"
         },
         "node_modules/markdownlint-cli/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19844,10 +19080,20 @@
             }
         },
         "node_modules/markdownlint-cli/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -20184,9 +19430,9 @@
             }
         },
         "node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -20452,9 +19698,9 @@
             }
         },
         "node_modules/nan": {
-            "version": "2.26.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-            "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+            "version": "2.28.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+            "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -20485,9 +19731,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -20778,10 +20024,20 @@
             }
         },
         "node_modules/npm-package-json-lint/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -21406,9 +20662,9 @@
             "license": "BlueOak-1.0.0"
         },
         "node_modules/pako": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-            "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
             "dev": true,
             "license": "(MIT AND Zlib)"
         },
@@ -21542,9 +20798,9 @@
             }
         },
         "node_modules/path-expression-matcher": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+            "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
             "dev": true,
             "funding": [
                 {
@@ -21788,9 +21044,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.22",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+            "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
             "dev": true,
             "funding": [
                 {
@@ -21808,7 +21064,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -22650,6 +21906,16 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -22838,13 +22104,14 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -24399,9 +23666,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-            "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+            "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -24419,15 +23686,15 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -24439,14 +23706,14 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -24555,14 +23822,16 @@
             }
         },
         "node_modules/simple-git": {
-            "version": "3.33.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.33.0.tgz",
-            "integrity": "sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==",
+            "version": "3.36.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+            "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@kwsites/file-exists": "^1.1.1",
                 "@kwsites/promise-deferred": "^1.1.1",
+                "@simple-git/args-pathspec": "^1.0.3",
+                "@simple-git/argv-parser": "^1.1.0",
                 "debug": "^4.4.0"
             },
             "funding": {
@@ -25254,9 +24523,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-            "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+            "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
             "dev": true,
             "funding": [
                 {
@@ -25264,7 +24533,10 @@
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "anynum": "^1.0.1"
+            }
         },
         "node_modules/stubborn-fs": {
             "version": "2.0.0",
@@ -25815,9 +25087,9 @@
             "dev": true
         },
         "node_modules/svgo": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-            "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+            "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -26215,9 +25487,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -26362,9 +25634,9 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -27295,9 +26567,9 @@
             }
         },
         "node_modules/webpack-bundle-analyzer/node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -27601,9 +26873,9 @@
             }
         },
         "node_modules/websocket-driver": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+            "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -27919,6 +27191,22 @@
                 "node": ">=18"
             }
         },
+        "node_modules/xml-naming": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+            "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/xml2js": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -28074,6 +27362,13 @@
             "peerDependencies": {
                 "zod": "^3.25.0 || ^4.0.0"
             }
+        },
+        "node_modules/zstddec": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+            "integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+            "dev": true,
+            "license": "MIT AND BSD-3-Clause"
         }
     }
 }

--- a/tests/playwright/global-setup.js
+++ b/tests/playwright/global-setup.js
@@ -79,6 +79,29 @@ async function globalSetup(config) {
       }
     }
 
+    // Clear cron hooks known to fatal ("Class ... not found") if they fire after their
+    // owning module's dependency is deactivated/removed mid-suite (e.g. a stale nfd_data_sync_cron
+    // surviving into a state where wp-module-data's autoloader isn't registered). WP-Cron retries
+    // a failing event on every subsequent page load, so one orphaned event can take down the rest
+    // of the run. Belt-and-suspenders alongside the upstream fix in wp-module-data (deactivation
+    // hook now clears these itself) — protects any site/branch still on an older module version.
+    // See: https://github.com/newfold-labs/wp-plugin-bluehost/pull/1380
+    //      https://github.com/newfold-labs/wp-module-data/pull/292
+    const orphanProneCronHooks = ['nfd_data_sync_cron', 'nfd_data_cron'];
+    for (const hook of orphanProneCronHooks) {
+      const result = await wordpress.wpCli(`cron event delete ${hook}`, {
+        failOnNonZeroExit: false,
+      });
+      if (wordpress.isWpCliFailure(result)) {
+        utils.fancyLog(
+          `⚠ Could not clear cron hook ${hook}: ${wordpress.formatWpCliResult(result)}`,
+          200,
+          'yellow',
+          '',
+        );
+      }
+    }
+
     utils.fancyLog('✔ Global setup completed successfully', 100, 'green', '');
   } catch (error) {
     utils.fancyLog(`✘ Global setup failed: ${error.message}`, 100, 'red', '');


### PR DESCRIPTION
## Proposed changes

Update modules:
- solutions: 2.10.3
- ~~onboarding: 3.3.7~~ **pinned at 3.3.6** — 3.3.7 ships a redesigned onboarding UI, but its own bundled Playwright spec still tests the old flow and fails entirely against the new one. That's a test/product mismatch inside `wp-module-onboarding`'s own repo, not something to fix here. Reverting so this PR isn't blocked on it.
- ~~data: 2.9.5~~ **pinned at 2.9.4** — 2.9.5 wasn't the actual cause of the e2e cascade below (it reproduced on both versions), but we're holding it here until the fix ships in a tagged release. See [newfold-labs/wp-module-data#292](https://github.com/newfold-labs/wp-module-data/pull/292).

Also:
- Bumped `.wp-env.json` core to WordPress 7.0.2 and plugin header `Tested up to: 7.0.2`.
- Added `WP_MEMORY_LIMIT`/`WP_MAX_MEMORY_LIMIT` (256M) to `.wp-env.json` — fixes an OOM crash cascade seen in the Playwright Test Matrix once additional module dependencies pushed baseline memory usage over the default 128M limit.
- Deferred `wp-module-deactivation`'s Playwright specs to run last in `.github/scripts/generate-playwright-projects.mjs` — its deactivation-survey test toggles the whole plugin's active state mid-suite, and running it early was letting a stale WP-Cron event (see below) take down dozens of unrelated modules' tests for the rest of the run.
- Added a defensive cron-hook clear in `tests/playwright/global-setup.js` for `nfd_data_sync_cron`/`nfd_data_cron`, belt-and-suspenders alongside the upstream fix in `wp-module-data#292`.

### Root cause of the e2e cascade (~66 failures → 9)

A WP-Cron event (`nfd_data_sync_cron`) scheduled by `wp-module-data` was never cleared on plugin deactivation. Once armed, WP-Cron retries it on every subsequent page load regardless of whether the owning plugin is active, fataling with `Class ... not found` each time — and since e2e ran the deactivation test mid-suite, it took the rest of the run down with it. Confirmed via `wp-module-insights`' own independent CI history that this is a systemic pattern (same signature, different classes: `SiteCapabilities`, `WC_Data_Store`, `wc_string_to_bool`) unrelated to this PR's module bumps. Fixed upstream in `wp-module-data#292` and mitigated here via test ordering + the defensive clear above.

### Remaining known-good failures (9, unrelated to the above)
- 6× `wp-module-onboarding` — the UI/test mismatch described above (out of scope here now that onboarding is reverted)
- 2× `wp-module-deactivation` — fixed upstream in [newfold-labs/wp-module-deactivation#125](https://github.com/newfold-labs/wp-module-deactivation/pull/125)
- 1× `wp-module-migration` — external domain (`migrate.bluehost.com`) unreachable from the CI sandbox, unrelated to this PR

## Type of Change




#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)



#### Development

- [x] Tests
- [x] Dependency update
- [x] Environment update / refactoring
- [ ] Documentation Update




## Visual









## Checklist



- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)




## Further comments

Related PRs: [wp-module-data#292](https://github.com/newfold-labs/wp-module-data/pull/292), [wp-module-deactivation#125](https://github.com/newfold-labs/wp-module-deactivation/pull/125)
