### PR TITLE
Default canAccessAI in the Cypress setCapability command

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -165,9 +165,18 @@ Cypress.Commands.add( 'wpCli', ( cmd, failOnNonZeroExit = true ) => {
  * @param {number} expiration seconds for transient to expire, defualt 3600 (1 hour)
  */
 Cypress.Commands.add( 'setCapability', ( capJSON, expiration = 3600 ) => {
+	const capabilities = { ...capJSON };
+
+	// Default canAccessAI only when omitted — callers can pass false to simulate no AI access.
+	// Without this key, capabilities are discarded by wp-module-data.
+	// see https://github.com/newfold-labs/wp-module-data/pull/285
+	if ( capabilities.canAccessAI === undefined ) {
+		capabilities.canAccessAI = true;
+	}
+
 	cy.wpCli(
 		`option update _transient_nfd_site_capabilities '${ JSON.stringify(
-			capJSON
+			capabilities
 		) }' --format=json`
 	);
 	// set transient expiration to one hour (default) from now


### PR DESCRIPTION
## Proposed changes

`tests/cypress/support/commands.js`'s `setCapability` Cypress command now defaults `canAccessAI: true` when the caller omits it, matching the fix already present in the Playwright equivalent (`tests/playwright/helpers/newfold.mjs`).

`wp-module-data`'s `SiteCapabilities::is_valid_capabilities()` ([wp-module-data#285](https://github.com/newfold-labs/wp-module-data/pull/285)) only accepts a capabilities array as valid if it contains the `canAccessAI` marker key — without it, `SiteCapabilities::all()` silently discards whatever was cached. The plugin's Playwright helper was already patched for this, but the older Cypress command was not, leaving the plugin with two inconsistent implementations of the same helper. This brings them back in sync.

Related follow-up from diagnosing the same issue surfacing in [wp-module-performance#601](https://github.com/newfold-labs/wp-module-performance/pull/601), [wp-plugin-bluehost#1387](https://github.com/newfold-labs/wp-plugin-bluehost/pull/1387), and [wp-module-data#293](https://github.com/newfold-labs/wp-module-data/pull/293).

## Type of Change

#### Development

- [x] Tests
- [ ] Documentation Update

## Further comments

No production code changed — test infrastructure only.


---
_Generated by [Claude Code](https://claude.ai/code/session_017ZMaQfcF8kbvMfsc3qmm5r)_