### PR TITLE
Cache Playwright browsers and drop --with-deps in CI

### DIFF
--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -178,8 +178,20 @@ jobs:
           npx wp-env run cli wp core version
           echo "WordPress is ready!"
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # Skip --with-deps: apt-get can hang on slow ubuntu mirrors. ubuntu-latest includes Chromium runtime libraries.
+      - name: Install Playwright Chromium
+        timeout-minutes: 5
+        run: npx playwright install chromium
 
       - name: Run Playwright Tests
         run: npx playwright test --reporter=line,json,github

--- a/.github/workflows/playwright-tests-beta.yml
+++ b/.github/workflows/playwright-tests-beta.yml
@@ -111,8 +111,20 @@ jobs:
       - name: Install WordPress
         run: npx wp-env start --debug
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # Skip --with-deps: apt-get can hang on slow ubuntu mirrors. ubuntu-latest includes Chromium runtime libraries.
+      - name: Install Playwright Chromium
+        timeout-minutes: 5
+        run: npx playwright install chromium
 
       - name: Run Playwright Tests
         run: npx playwright test --reporter=line

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -192,8 +192,20 @@ jobs:
           npx wp-env run cli wp core version
           echo "WordPress is ready!"
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # Skip --with-deps: apt-get can hang on slow ubuntu mirrors. ubuntu-latest includes Chromium runtime libraries.
+      - name: Install Playwright Chromium
+        timeout-minutes: 5
+        run: npx playwright install chromium
 
       - name: Run Playwright Tests
         run: npx playwright test --reporter=line


### PR DESCRIPTION
## Summary
- Cache Chromium browser binaries in `~/.cache/ms-playwright`, keyed on the pinned `@playwright/test` version
- Replace `npx playwright install --with-deps chromium` with `npx playwright install chromium` and a 5-minute timeout in all Playwright workflows (`playwright-tests.yml`, `playwright-matrix.yml`, `playwright-tests-beta.yml`)
- Avoids CI stalls from slow `apt-get` mirrors when `--with-deps` runs on `ubuntu-latest`

## Test plan
- [ ] Playwright Tests workflow completes browser install step on a PR
- [ ] Playwright matrix jobs pass across PHP/WP combinations
- [ ] WordPress beta Playwright workflow still passes


Made with [Cursor](https://cursor.com)