### PR TITLE
Fix Playwright version shell quoting in workflow files

### DIFF
--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -180,8 +180,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: |
-          echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(node -e 'console.log(require("@playwright/test/package.json").version)')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -194,8 +194,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: |
-          echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(node -e 'console.log(require("@playwright/test/package.json").version)')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0


### PR DESCRIPTION
## Summary

Fixes the "Get Playwright version" step in both `playwright-tests.yml` and `playwright-matrix.yml`, which was failing with a shell syntax error.

**Root cause:** Backslash-escaped double quotes (`\"`) inside `$(...)` command substitution don't work as expected in bash — the shell sees unmatched quotes and throws `syntax error near unexpected token '('`.

**Fix:** Switch from:
```yaml
run: |
  echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
```
to:
```yaml
run: echo "version=$(node -e 'console.log(require("@playwright/test/package.json").version)')" >> "$GITHUB_OUTPUT"
```

Single quotes inside `$(...)` are completely literal to bash, so this form parses cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJsc4dt6ya6BEXsmqKDSrg)_