### PR TITLE
Fix Playwright version shell quoting in playwright-tests-beta.yml

### DIFF
--- a/.github/workflows/playwright-tests-beta.yml
+++ b/.github/workflows/playwright-tests-beta.yml
@@ -113,8 +113,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: |
-          echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(node -e 'console.log(require("@playwright/test/package.json").version)')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0


### PR DESCRIPTION
## Summary

Fixes the same shell quoting bug in `playwright-tests-beta.yml` that was already fixed in `playwright-tests.yml` and `playwright-matrix.yml` via #1468. This file was flagged by the **Scan & Lint Workflow Files** (`actionlint`) check after that PR was merged.

**Root cause:** Backslash-escaped double quotes (`\"`) inside `$(...)` don't work in bash — shellcheck reports SC1036/SC1072/SC1073.

**Fix:** Switch from:
```yaml
run: |
  echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
```
to:
```yaml
run: echo "version=$(node -e 'console.log(require("@playwright/test/package.json").version)')" >> "$GITHUB_OUTPUT"
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJsc4dt6ya6BEXsmqKDSrg)_