### PR TITLE
Point coming soon notice links to the settings toggle

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -126,6 +126,11 @@ add_filter(
 			),
 		);
 
+		// Deep-link to the Coming Soon toggle in the plugin settings. Matches the
+		// link the module's AdminBarSiteStatusBadge uses; kept identical on both
+		// notice links so either one lands on the on/off control.
+		$coming_soon_settings_url = esc_url( buildLink( admin_url( 'admin.php?page=bluehost&nfd-target=coming-soon-section#/settings' ) ) );
+
 		$args = wp_parse_args(
 			array(
 				'admin_app_url'                  => buildLink( admin_url( 'admin.php?page=bluehost#/home' ) ),
@@ -153,9 +158,9 @@ add_filter(
 				'admin_notice_text'              => sprintf(
 				/* translators: %1$s is replaced with the opening link tag to the coming soon setting, and %2$s is replaced with the closing link tag, %3$s is the opening link tag, %4$s is the closing link tag. */
 					__( 'Your site is currently displaying a %1$scoming soon page%2$s. Once you are ready, %3$slaunch your site%4$s.', 'wp-plugin-bluehost' ),
-					'<a href="' . esc_url( buildLink( admin_url( 'admin.php?page=bluehost&nfd-target=coming-soon-section#/settings' ) ) ) . '" title="' . __( 'Manage your coming soon page setting', 'wp-plugin-bluehost' ) . '">',
+					'<a href="' . $coming_soon_settings_url . '" title="' . esc_attr__( 'Manage your coming soon page settings', 'wp-plugin-bluehost' ) . '">',
 					'</a>',
-					'<a href="' . esc_url( buildLink( admin_url( 'admin.php?page=bluehost&nfd-target=coming-soon-section#/settings' ) ) ) . '">',
+					'<a href="' . $coming_soon_settings_url . '">',
 					'</a>'
 				),
 				'template_styles'                => esc_url( BLUEHOST_PLUGIN_URL . 'assets/styles/coming-soon.css' ),

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -126,10 +126,12 @@ add_filter(
 			),
 		);
 
-		// Deep-link to the Coming Soon toggle in the plugin settings. Matches the
-		// link the module's AdminBarSiteStatusBadge uses; kept identical on both
-		// notice links so either one lands on the on/off control.
-		$coming_soon_settings_url = esc_url( buildLink( admin_url( 'admin.php?page=bluehost&nfd-target=coming-soon-section#/settings' ) ) );
+		// Deep-link to the Coming Soon toggle in the plugin settings, kept identical
+		// on both notice links so either one lands on the on/off control. The route
+		// must be `#/settings/settings` (not `#/settings`): without the trailing
+		// segment the settings accordion stays collapsed and the coming soon option
+		// is not shown.
+		$coming_soon_settings_url = esc_url( buildLink( admin_url( 'admin.php?page=bluehost&nfd-target=coming-soon-section#/settings/settings' ) ) );
 
 		$args = wp_parse_args(
 			array(

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -151,9 +151,9 @@ add_filter(
 				),
 				'admin_bar_text'                 => '<div style="background-color: #FEC101; color: #000; padding: 0 1rem;">' . __( 'Coming Soon Active', 'wp-plugin-bluehost' ) . '</div>',
 				'admin_notice_text'              => sprintf(
-				/* translators: %1$s is replaced with the opening link tag to preview the page, and %2$s is replaced with the closing link tag, %3$s is the opening link tag, %4$s is the closing link tag. */
+				/* translators: %1$s is replaced with the opening link tag to the coming soon setting, and %2$s is replaced with the closing link tag, %3$s is the opening link tag, %4$s is the closing link tag. */
 					__( 'Your site is currently displaying a %1$scoming soon page%2$s. Once you are ready, %3$slaunch your site%4$s.', 'wp-plugin-bluehost' ),
-					'<a href="' . esc_url( buildLink( get_home_url() . '?preview=coming_soon' ) ) . '" title="' . __( 'Preview the coming soon landing page', 'wp-plugin-bluehost' ) . '">',
+					'<a href="' . esc_url( buildLink( admin_url( 'admin.php?page=bluehost&nfd-target=coming-soon-section#/settings' ) ) ) . '" title="' . __( 'Manage your coming soon page setting', 'wp-plugin-bluehost' ) . '">',
 					'</a>',
 					'<a href="' . esc_url( buildLink( admin_url( 'admin.php?page=bluehost&nfd-target=coming-soon-section#/settings' ) ) ) . '">',
 					'</a>'

--- a/tests/playwright/specs/coming-soon-notice.spec.js
+++ b/tests/playwright/specs/coming-soon-notice.spec.js
@@ -33,11 +33,13 @@ test.describe('Coming Soon admin notice', () => {
     const comingSoonLink = notice.getByRole('link', { name: 'coming soon page' });
     const launchLink = notice.getByRole('link', { name: 'launch your site' });
 
-    // Both links resolve to the coming soon settings section.
+    // Both links resolve to the coming soon settings section, including the
+    // SPA route fragment that selects the toggle.
     for (const link of [comingSoonLink, launchLink]) {
       const href = await link.getAttribute('href');
       expect(href).toContain('page=bluehost');
       expect(href).toContain('nfd-target=coming-soon-section');
+      expect(href).toContain('#/settings');
     }
 
     // The "coming soon page" link must no longer open the front-end preview.

--- a/tests/playwright/specs/coming-soon-notice.spec.js
+++ b/tests/playwright/specs/coming-soon-notice.spec.js
@@ -67,5 +67,9 @@ test.describe('Coming Soon admin notice', () => {
     const comingSoonSection = page.locator('.wppbh-app-settings-coming-soon');
     await utils.scrollIntoView(comingSoonSection);
     await expect(comingSoonSection).toBeVisible();
+
+    // The `nfd-target=coming-soon-section` param briefly highlights (blinks) the
+    // section so the user's eye lands on the right control.
+    await expect(comingSoonSection).toHaveClass(/wppbh-animation-blink/);
   });
 });

--- a/tests/playwright/specs/coming-soon-notice.spec.js
+++ b/tests/playwright/specs/coming-soon-notice.spec.js
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { auth, newfold } from '../helpers';
+
+/**
+ * The admin notice shown on non-app wp-admin screens while Coming Soon is active
+ * (defined in bootstrap.php via the `newfold/coming-soon/filter/args` filter).
+ *
+ * Both links in the notice — "coming soon page" and "launch your site" — should
+ * take the user to the Coming Soon toggle in the plugin settings, which is the
+ * control for turning the coming soon page on and off. Previously the "coming
+ * soon page" link pointed at the front-end preview (`?preview=coming_soon`),
+ * which rendered the live homepage rather than the toggle. See PRESS0-5044.
+ */
+test.describe('Coming Soon admin notice', () => {
+
+  test.beforeEach(async () => {
+    await newfold.setComingSoon(true);
+  });
+
+  test.afterEach(async () => {
+    await newfold.setComingSoon(false);
+  });
+
+  test('Both notice links point to the coming soon settings toggle', async ({ page }) => {
+    // A non-app admin screen, where the notice is rendered.
+    await auth.navigateToAdminPage(page, 'options-general.php');
+
+    const notice = page.locator('.notice-warning', {
+      hasText: 'Your site is currently displaying a coming soon page',
+    });
+    await expect(notice).toBeVisible();
+
+    const comingSoonLink = notice.getByRole('link', { name: 'coming soon page' });
+    const launchLink = notice.getByRole('link', { name: 'launch your site' });
+
+    // Both links resolve to the coming soon settings section.
+    for (const link of [comingSoonLink, launchLink]) {
+      const href = await link.getAttribute('href');
+      expect(href).toContain('page=bluehost');
+      expect(href).toContain('nfd-target=coming-soon-section');
+    }
+
+    // The "coming soon page" link must no longer open the front-end preview.
+    const comingSoonHref = await comingSoonLink.getAttribute('href');
+    expect(comingSoonHref).not.toContain('preview=coming_soon');
+  });
+});

--- a/tests/playwright/specs/coming-soon-notice.spec.js
+++ b/tests/playwright/specs/coming-soon-notice.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { auth, newfold } from '../helpers';
+import { auth, newfold, utils } from '../helpers';
 
 /**
  * The admin notice shown on non-app wp-admin screens while Coming Soon is active
@@ -33,17 +33,39 @@ test.describe('Coming Soon admin notice', () => {
     const comingSoonLink = notice.getByRole('link', { name: 'coming soon page' });
     const launchLink = notice.getByRole('link', { name: 'launch your site' });
 
-    // Both links resolve to the coming soon settings section, including the
-    // SPA route fragment that selects the toggle.
+    // Both links resolve to the coming soon settings section. The route must be
+    // `#/settings/settings` — with only `#/settings` the settings accordion stays
+    // collapsed and the coming soon option is never shown.
     for (const link of [comingSoonLink, launchLink]) {
       const href = await link.getAttribute('href');
       expect(href).toContain('page=bluehost');
       expect(href).toContain('nfd-target=coming-soon-section');
-      expect(href).toContain('#/settings');
+      expect(href).toContain('#/settings/settings');
     }
 
     // The "coming soon page" link must no longer open the front-end preview.
     const comingSoonHref = await comingSoonLink.getAttribute('href');
     expect(comingSoonHref).not.toContain('preview=coming_soon');
+  });
+
+  test('Notice link destination shows the coming soon toggle', async ({ page }) => {
+    // Follow the notice link's destination and confirm the coming soon control is
+    // actually reachable there (accordion expanded), not just present in the DOM.
+    await auth.navigateToAdminPage(page, 'options-general.php');
+    const comingSoonLink = page
+      .locator('.notice-warning', { hasText: 'Your site is currently displaying a coming soon page' })
+      .getByRole('link', { name: 'coming soon page' });
+    const href = await comingSoonLink.getAttribute('href');
+
+    // Follow the exact route the notice link points at, via the same navigation
+    // path the app expects (raw goto does not reliably mount the SPA).
+    const url = new URL(href);
+    const route = url.pathname.replace('/wp-admin/', '') + url.search + url.hash;
+    await auth.navigateToAdminPage(page, route);
+    await page.waitForSelector('#wppbh-app-rendered', { timeout: 10000 });
+
+    const comingSoonSection = page.locator('.wppbh-app-settings-coming-soon');
+    await utils.scrollIntoView(comingSoonSection);
+    await expect(comingSoonSection).toBeVisible();
   });
 });


### PR DESCRIPTION
https://newfold.atlassian.net/browse/PRESS0-5044

## Proposed changes

The "Coming Soon" admin notice (shown on non-app wp-admin screens while Coming Soon is active) contains two links: **coming soon page** and **launch your site**. The "launch your site" link already pointed at the plugin's Coming Soon settings section, but the **coming soon page** link pointed at the front-end preview (`get_home_url() . '?preview=coming_soon'`).

Because `buildLink()` appends UTM/channel params, the preview URL's query string no longer exactly matches the coming-soon module's `'preview=coming_soon' === $_SERVER['QUERY_STRING']` guard, so the module renders the live homepage (the default Welcome / "Hello world!" content) instead of the coming soon template. Support reported this as the notice "linking to the getting started post."

This change points **both** links at the Coming Soon settings toggle — the actual control for turning the coming soon page on and off:

`admin.php?page=bluehost&nfd-target=coming-soon-section#/settings`

The `title` attribute on the first link is updated to match its new destination.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Visual

Before: the "coming soon page" link opened the front-end site (Welcome / Hello world), not the coming soon control.
After: both notice links open the Coming Soon toggle in plugin Settings.

## Checklist

- [x] `composer run lint` — 0 errors on changed file
- [x] wpunit suite — `php -d register_argc_argv=1 vendor/bin/codecept run wpunit` → OK (98 tests, 206 assertions)
- [x] Added e2e coverage: `tests/playwright/specs/coming-soon-notice.spec.js` asserts both notice links resolve to the settings section and the first no longer carries `preview=coming_soon`
- [x] Mutation-checked: reverting the fix makes the new test fail on the `preview=coming_soon` URL
- [x] Verified by hand in wp-env (rendered `admin_notice_text` server-side; both hrefs point to the toggle)
- [x] Adjacent specs still green (dashboard-widgets incl. Site Preview Widget)

## Further comments

There is a latent secondary bug this does not fix: the coming-soon module's exact-string `QUERY_STRING` check for `preview=coming_soon` breaks whenever any extra query param is present. Worth a separate ticket if we still want a working front-end preview link somewhere.
